### PR TITLE
Add dwave.samplers and dwave.composite namespace

### DIFF
--- a/dwave/__init__.py
+++ b/dwave/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+import pkgutil
+__path__ = pkgutil.extend_path(__path__, __name__)

--- a/dwave/composites/__init__.py
+++ b/dwave/composites/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+from pkg_resources import iter_entry_points
+
+# add the composites to the module from entrypoints, name conflicts override
+globals().update((ep.name, ep.load()) for ep in iter_entry_points('dwave.composites'))
+del iter_entry_points  # remove from namespace

--- a/dwave/composites/__init__.py
+++ b/dwave/composites/__init__.py
@@ -13,6 +13,22 @@
 #    limitations under the License.
 #
 # ================================================================================================
+"""
+A unified namespace for :class:`dimod.Composite`s.
+
+This namespace is populated by entry points. To contribute a composite, you
+must identify it in your setup.py file like so.
+
+.. code-block:: python
+
+    entry_points = {'dwave.composites': ['YourComposite = import.path.to.composite:YourComposite']}
+
+    setup(
+        entry_points=entry_points,
+        ...
+    )
+
+"""
 from pkg_resources import iter_entry_points
 
 # add the composites to the module from entrypoints, name conflicts override

--- a/dwave/samplers/__init__.py
+++ b/dwave/samplers/__init__.py
@@ -1,0 +1,20 @@
+# Copyright 2018 D-Wave Systems Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# ================================================================================================
+from pkg_resources import iter_entry_points
+
+# add the samplers to the module from entrypoints, name conflicts override
+globals().update((ep.name, ep.load()) for ep in iter_entry_points('dwave.samplers'))
+del iter_entry_points  # remove from namespace

--- a/dwave/samplers/__init__.py
+++ b/dwave/samplers/__init__.py
@@ -13,6 +13,22 @@
 #    limitations under the License.
 #
 # ================================================================================================
+"""
+A unified namespace for :class:`dimod.Sampler`s.
+
+This namespace is populated by entry points. To contribute a sampler, you
+must identify it in your setup.py file like so.
+
+.. code-block:: python
+
+    entry_points = {'dwave.samplers': ['YourSampler = import.path.to.sampler:YourSampler']}
+
+    setup(
+        entry_points=entry_points,
+        ...
+    )
+
+"""
 from pkg_resources import iter_entry_points
 
 # add the samplers to the module from entrypoints, name conflicts override

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,9 @@
 # ================================================================================================
 from __future__ import absolute_import
 
+import os
 import sys
+
 from setuptools import setup
 
 _PY2 = sys.version_info.major == 2
@@ -26,6 +28,8 @@ if _PY2:
     execfile("./dwaveoceansdk/package_info.py")
 else:
     exec(open("./dwaveoceansdk/package_info.py").read())
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
 install_requires = [
     'dwave-networkx>=0.6.1,<0.7.0',
@@ -43,7 +47,11 @@ extras_require = {
     ]
 }
 
-packages = ['dwaveoceansdk']
+packages = ['dwaveoceansdk',
+            'dwave',
+            'dwave.samplers',
+            'dwave.composites',
+            ]
 
 classifiers = [
     'License :: OSI Approved :: Apache Software License',

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,0 +1,9 @@
+import unittest
+
+
+class Test_dwave_samplers(unittest.TestCase):
+    pass
+
+
+class Test_dwave_composites(unittest.TestCase):
+    pass


### PR DESCRIPTION
Create a namespace for Samplers and Composites populated by entry points.

We could also consider having this as a separate package rather than part of the SDK.