### PR TITLE
Require ComposedPolySampler for dwave-system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
     'dwave-hybrid>=0.2.0,<0.3.0',
     'dwave-neal>=0.4.0,<0.5.0',
     'dwave-tabu>=0.1.3,<0.2.0',
-    'dimod>=0.8.0,<0.9.0',
+    'dimod>=0.8.12,<0.9.0',
     'numpy<1.16.0',     # only while we support py34
     'pyqubo>=0.3.0',
 ]


### PR DESCRIPTION
SDK 1.3.0 requires dimod 0.8.0 which doesn't have `from dimod.core.polysampler import PolySampler, ComposedPolySampler` but dwave-system has `class PolyCutOffComposite(dimod.ComposedPolySampler):`
that breaks:

```Running Sphinx v1.7.2

Configuration error:
There is a programable error in your configuration file:

Traceback (most recent call last):
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\sphinx\config.py", line 161, in __init__
    execfile_(filename, config)
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\sphinx\util\pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "c:\users\jpasvolsky\!git_docsos\env\lib\site-packages\six.py", line 709, in exec_
    exec("""exec _code_ in _globs_, _locs_""")
  File "<string>", line 1, in <module>
  File "conf.py", line 66, in <module>
    import dwave.system.package_info
  File "C:\Users\jpasvolsky\!git_DocsOS\env\ADTT\dwave-system\dwave\system\__init__.py", line 21, in <module>
    from dwave.system.composites import *
  File "C:\Users\jpasvolsky\!git_DocsOS\env\ADTT\dwave-system\dwave\system\composites\__init__.py", line 16, in <module>
    from dwave.system.composites.cutoffcomposite import *
  File "C:\Users\jpasvolsky\!git_DocsOS\env\ADTT\dwave-system\dwave\system\composites\cutoffcomposite.py", line 180, in <module>
    class PolyCutOffComposite(dimod.ComposedPolySampler):
AttributeError: 'module' object has no attribute 'ComposedPolySampler'

```