### PR TITLE
Fix doctest on hybrid example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,9 @@ import operator         # Used by dwave-binarycsp
 # Set up mocking for DWaveSampler 
 from dwave.system.testing import MockDWaveSampler
 import dwave.system
+import hybrid
 dwave.system.DWaveSampler = MockDWaveSampler
+hybrid.samplers.DWaveSampler = MockDWaveSampler
 
 from dwave.system import *
 from dwave.embedding import *

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,7 +100,6 @@ import operator         # Used by dwave-binarycsp
 from dwave.system.testing import MockDWaveSampler
 import dwave.system
 dwave.system.DWaveSampler = MockDWaveSampler
-dwave.system.samplers.DWaveSampler = MockDWaveSampler
 
 from dwave.system import *
 from dwave.embedding import *

--- a/docs/examples/hybrid1.rst
+++ b/docs/examples/hybrid1.rst
@@ -83,12 +83,6 @@ the D-Wave system, and merges the subproblem's samples into the latest problem s
 In this case, subproblems contain 30 variables in a rolling window that can cover up
 to 75 percent of the problem's variables.
 
-.. testsetup::
-
-   import hybrid
-   import functools
-   hybrid.QPUSubproblemAutoEmbeddingSampler = functools.partial(hybrid.QPUSubproblemAutoEmbeddingSampler, qpu_sampler=MockDWaveSampler())
-
 .. testcode::
 
     # Set a workflow of tabu search in parallel to submissions to a D-Wave system

--- a/docs/examples/hybrid1.rst
+++ b/docs/examples/hybrid1.rst
@@ -83,6 +83,12 @@ the D-Wave system, and merges the subproblem's samples into the latest problem s
 In this case, subproblems contain 30 variables in a rolling window that can cover up
 to 75 percent of the problem's variables.
 
+.. testsetup::
+
+   import hybrid
+   import functools
+   hybrid.QPUSubproblemAutoEmbeddingSampler = functools.partial(hybrid.QPUSubproblemAutoEmbeddingSampler, qpu_sampler=MockDWaveSampler())
+
 .. testcode::
 
     # Set a workflow of tabu search in parallel to submissions to a D-Wave system
@@ -93,7 +99,6 @@ to 75 percent of the problem's variables.
           hybrid.EnergyImpactDecomposer(size=30, rolling=True, rolling_history=0.75)
           | hybrid.QPUSubproblemAutoEmbeddingSampler()
           | hybrid.SplatComposer()) | hybrid.ArgMin(), convergence=3)
-
 
 Solve the Problem Using Hybrid Resources
 ========================================


### PR DESCRIPTION
With 
- [x] https://github.com/dwavesystems/dwave-cloud-client/pull/374 -- in 0.7.2, sdk 2.1.1, 
- [x] dwavebinarycsp release https://github.com/dwavesystems/dwavebinarycsp/releases/tag/0.1.2 -- in sdk 2.1.1,  
- [x] https://github.com/dwavesystems/dimod/pull/640 -- in 0.9.2
- [x] https://github.com/dwavesystems/dwave-inspector/pull/86 -- in 0.2.0
- [x] https://github.com/dwavesystems/dwave-system/pull/282 -- in 0.9.4, sdk 2.1.1

doctests should all pass:
```
Doctest summary
===============
 1235 tests
    0 failure in tests
    0 failures in setup code
    0 failures in cleanup code
```