### PR TITLE
fix PyQUBO version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = [
     'penaltymodel-cache==0.4.1',
     'penaltymodel-lp==0.1.3',
     'penaltymodel==0.16.3',
-    'pyqubo>=0.4.0',
+    'pyqubo==0.4.0',
 ]
 
 # note: when updating the version of maxgap, it also must be updated in


### PR DESCRIPTION
I will release a new C++ version of PyQUBO soon.
Before then, I would like to fix the version of PyQUBO to avoid unexpected error which might occur when installing a new PyQUBO.
After I will release a new PyQUBO, I will update the version of PyQUBO specified in dwave-ocean-sdk.
