### PR TITLE
Update .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,10 +2,10 @@
 Language: Cpp
 BasedOnStyle: Google
 
-ColumnLimit: 120
+ColumnLimit: 80
 NamespaceIndentation: Inner
 
 # Scaled by a factor of 2 such that the base indent is 4
-AccessModifierOffset: -2
+AccessModifierOffset: -3
 IndentWidth: 4
 ...

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -144,7 +144,6 @@ Format
 
 * Our format is based on `Google C++ style guide <https://google.github.io/styleguide/cppguide.html>`_ with some exceptions:
 
-  - Column width is limited to 120 characters. Best effort should be made to keep to 80 characters, but up to 120 can be used for clarity.
   - The base indent level is 4.
   - Non-const references are allowed.
 


### PR DESCRIPTION
* Change ColumnLimit to 80, otherwise it will try to use as much space as possible
* Change AccessModifierOffset to -3 to make it consistent with Google style

See also #90 