### PR TITLE
Minor documentation updates

### DIFF
--- a/docs/concepts/embedding.rst
+++ b/docs/concepts/embedding.rst
@@ -90,6 +90,8 @@ intentionally sets the embedding shown below to represent this same :math:`K_3` 
 
 	Three-variable :math:`K_3` fully-connected problem is embedded in six qubits on a D-Wave 2000Q. Variable :math:`s_0`, highlighted in dark magenta, is represented by three qubits, numbers 0, 4, and 7; Variable :math:`s_2` is represented by two qubits, numbers 3 and 6, shown with their connecting edge emphasized (and displaying a solution of :math:`+1`).
 
+.. _concepts__chain_strength:
+
 Chain Strength
 --------------
 

--- a/docs/examples/and.rst
+++ b/docs/examples/and.rst
@@ -338,7 +338,7 @@ to view the solution on the QPU.
   View of the logical and embedded problem rendered by Ocean's problem inspector. The AND gate's original QUBO is represented on the left; its embedded representation, on the right, shows a two-qubit chain of qubits 0 and 4 for variable Z. The current solution displayed, :math:`X1=1, X2=0, Z=0`, is represented by white and gold dots for binary :math:`0, 1` and white and blue dots for spin values :math:`-1, 1`.
 
 For comparison, the following code purposely weakens the 
-:ref:`chain strength <embedding_sdk>` (strength of the
+:ref:`concepts__chain_strength` (strength of the
 coupler between qubits 0 and 4, which represents variable :math:`z`). The first
 line prints the range of values available for the D-Wave system this code is executed
 on. By explicitly setting chain strength to a low value of 0.25, the two qubits are not 

--- a/docs/examples/and.rst
+++ b/docs/examples/and.rst
@@ -202,7 +202,7 @@ is adjacent to qubit 4 and four others. On an Advantage system with its Pegasus
 topology, you might see an output such as this:
 
 >>> print(sampler.adjacency[sampler.nodelist[0]])      # doctest: +SKIP
-{15}
+{31, 2940, 2955, 2970, 2985}
 
 You can map the NOT problem's two linear coefficients and single quadratic coefficient,
 :math:`q_1=q_2=-1` and :math:`q_{1,2}=2`, to biases on the D-Wave 2000Q's qubits 0 and 4 
@@ -242,7 +242,7 @@ As before, ask for 5000 samples.
 
 On an Advantage system, the code above might set an embedding such as:
 
->>> sampler_embedded = FixedEmbeddingComposite(sampler, {'x': [0], 'z': [4]})
+>>> sampler_embedded = FixedEmbeddingComposite(sampler, {'x': [30], 'z': [31]})
 
 From NOT to AND: an Important Difference
 ----------------------------------------

--- a/docs/overview/stack.rst
+++ b/docs/overview/stack.rst
@@ -115,7 +115,7 @@ each stage of the process to a layer of the Ocean stack.
         - Simulated annealing sampler for testing.
         - For code-development testing.
       * - Classical
-        - :doc:`dwave-neal </docs_greedy/sdk_index>` :class:`~greedy.sampler.SteepestDescentSolver`.
+        - :doc:`dwave-greedy </docs_greedy/sdk_index>` :class:`~greedy.sampler.SteepestDescentSolver`.
         - A steepest-descent solver for binary quadratic models.
         - For post-processing and convex problems.
       * - Classical


### PR DESCRIPTION
* Fix label in Ocean samplers table: `dwave-neal` -> `dwave-greedy`
* Update some node adjacency values for the Advantage system in the AND gate example.  Please review changes.  The previous text showed only a single node in the adjacency printout, and then it also used the same code for the `FixedEmbeddingComposite` example with Advantage as with 2000Q, which did not seem to be correct.  I got the new adjacency values using the "Advantage_system1.1" solver.
* 24652f9 and af94286 are both changes to link directly to topical subsections in the documentation that are being referenced in the text.  As a first-time reader, this would make it easier for me to find the information that is being referred to.  Happy to rebase and back these out though if this is not the preferred style.