### PR TITLE
More minor documentation updates

### DIFF
--- a/docs/examples/hybrid1.rst
+++ b/docs/examples/hybrid1.rst
@@ -59,7 +59,7 @@ Formulate the Problem
 
 This example uses a synthetic problem for illustrative purposes: a NetworkX
 generated graph,
-`NetworkX barabasi_albert_graph() <https://networkx.github.io/documentation/stable/reference/generators.html#module-networkx.generators.random>`_\ , with random +1 or -1
+`NetworkX barabasi_albert_graph() <https://networkx.github.io/documentation/stable/reference/generators.html#module-networkx.generators>`_\ , with random +1 or -1
 couplings assigned to its edges.
 
 .. testcode::

--- a/docs/examples/hybrid_solver_service.rst
+++ b/docs/examples/hybrid_solver_service.rst
@@ -65,13 +65,13 @@ For a social graph, `G`, this example simply builds a random sparse graph---usin
 `NetworkX <https://networkx.github.io/>`_ :func:`~networkx.generators.geometric.random_geometric_graph()` 
 function, which places uniformly at random a specified number of nodes, `problem_node_count`, 
 in a unit cube, joining edges of any two if the distance is below a given radius---and randomly
-assigns :math:`0, 1` signs to represent friendly and hostile relationships.
+assigns :math:`-1, 1` signs to represent friendly and hostile relationships.
 
 >>> import networkx as nx
 >>> import random
 >>> problem_node_count = 300
 >>> G = nx.random_geometric_graph(problem_node_count, radius=0.0005*problem_node_count)
->>> G.add_edges_from([(u, v, {'sign': 2*random.randint(0, 1)-1}) for u, v in G.edges])
+>>> G.add_edges_from([(u, v, {'sign': random.choice((-1, 1))}) for u, v in G.edges])
 
 Solve the Problem by Sampling
 =============================

--- a/docs/examples/multi_gate.rst
+++ b/docs/examples/multi_gate.rst
@@ -91,7 +91,7 @@ Formulating the Problem as a CSP
 This example demonstrates two formulations of constraints from the problem's
 logic gates:
 
-#. Single comprehensive constraint.
+1. Single comprehensive constraint.
 
 .. testcode::
 
@@ -111,7 +111,7 @@ logic gates:
     csp.add_constraint(logic_circuit, ['a', 'b', 'c', 'd', 'z'])
 
 
-#. Multiple small constraints.
+2. Multiple small constraints.
 
 .. testcode::
 


### PR DESCRIPTION
In the case of the NetworkX random graphs link, I think it would be the most clear to link directly to the documentation for `barabasi_albert_graph` (https://networkx.org/documentation/stable/reference/generated/networkx.generators.random_graphs.barabasi_albert_graph.html#networkx.generators.random_graphs.barabasi_albert_graph) instead of the random graphs section, but I'm not sure if that works with the github.io URL format or if there is a reason for using that instead of networkx.org.