### PR TITLE
Link to GitHub source code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,7 +376,8 @@ def linkcode_resolve(domain, info):
     linespec = ""
     try:
         source, lineno = inspect.getsourcelines(obj[obj_inx])
-        linespec = "#L%d" % (lineno)
+        if obj_inx != 0:
+           linespec = "#L%d" % (lineno) 
     except Exception:
         linespec = ""
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -337,7 +337,6 @@ with open('../dwave_ocean_sdk.egg-info/requires.txt', 'r') as requires_txt:
                if repo[0] in line:
                   github_map[gh].append(line.split('==')[1].rstrip())
 
-
 def linkcode_resolve(domain, info):
     """
     Find the URL of the GitHub source for dwave-ocean-sdk objects.
@@ -389,17 +388,17 @@ def linkcode_resolve(domain, info):
     else:
        fn = fn.replace(fn[:fn.index("site-packages")+len("site-packages")], "") 
 
-    target = fn.split("/")
-    repo = target[1] if not target[1] == "dwave" else target[2]
+    repo = fn.split("/")[1] if  \
+           (fn.split("/")[1] != "dwave") and (fn.split("/")[1] != "penaltymodel") \
+           else fn.split("/")[2]
 
-    if repo == 'penaltymodel':
-        fn = "https://github.com/dwavesystems/penaltymodel/tree/" +  \
-             info['module'].split('.')[1] + "-" + \
-             github_map['penaltymodel'][0][info['module'].split('.')[1]][1] + "/" + \
-             github_map['penaltymodel'][0][info['module'].split('.')[1]][0] + fn
+    if fn.split("/")[1] == 'penaltymodel':
+        pm_pkg = github_map['penaltymodel'][0][repo]
+        fn = "https://github.com/dwavesystems/penaltymodel/tree/{}-{}/{}{}".format( \
+             repo, pm_pkg[1], pm_pkg[0], fn)
     else:
-        fn = "https://github.com/dwavesystems/" + github_map[repo][0] + "/blob/" + \
-             github_map[repo][1] + fn     
+        pkg = github_map[repo]
+        fn = "https://github.com/dwavesystems/{}/blob/{}{}".format(pkg[0], pkg[1], fn) 
  
     return fn + linespec
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -316,7 +316,6 @@ github_map = {'dwavebinarycsp': 'dwavebinarycsp',
               'embedding': 'dwave-system',
               'tabu': 'dwave-tabu'}
 
-#f= open("info_sdk.txt","w+")
 def linkcode_resolve(domain, info):
     """
     Find the URL of the GitHub source for dwave-ocean-sdk objects.
@@ -324,7 +323,6 @@ def linkcode_resolve(domain, info):
     # Based on https://github.com/numpy/numpy/blob/main/doc/source/conf.py
 
     if domain != 'py':
-        #f.write("\n  C: " + info['module'] + " -->" + info['fullname'])
         return None
 
     obj = sys.modules.get(info['module'])
@@ -332,7 +330,6 @@ def linkcode_resolve(domain, info):
         try:
             obj = getattr(obj, part)
         except Exception:
-            #f.write("\n  Exception1: " + info['module'] + " -->" + info['fullname'])
             return None
 
     # strip decorators, which would resolve to the source of the decorator
@@ -347,7 +344,6 @@ def linkcode_resolve(domain, info):
     try:
         fn = inspect.getsourcefile(obj)
     except Exception:
-        #f.write("\n  Exception2: " + info['module'] + " -->" + info['fullname'])
         return None
 
     try:
@@ -357,7 +353,6 @@ def linkcode_resolve(domain, info):
         lineno = ""
 
     if not fn or not "site-packages" in fn:
-       #f.write("\n  NO FN: " + info['module'] + " -->" + info['fullname'])
        return None
     
     if ".egg" in fn:
@@ -368,7 +363,6 @@ def linkcode_resolve(domain, info):
     target = fn.split("/")
     repo = target[1] if not target[1] == "dwave" else target[2]
 
-
     if repo in ["minorminer", ]:
         fn = "https://github.com/dwavesystems/" + github_map[repo] + "/blob/main" + fn
     elif repo == 'penaltymodel':
@@ -377,7 +371,5 @@ def linkcode_resolve(domain, info):
     else:
         fn = "https://github.com/dwavesystems/" + github_map[repo] + "/blob/master" + fn     
  
-    #f.write("\nLink: " + fn + "  --> " + linespec)
-
     return fn + linespec
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -310,6 +310,7 @@ github_map = {'dwavebinarycsp': 'dwavebinarycsp',
               'penaltymodel': {'cache': 'penaltymodel_cache',
                                'core': 'penaltymodel_core',
                                'lp': 'penaltymodel_lp',
+                               'maxgap': 'penaltymodel_maxgap',
                                'mip': 'penaltymodel_mip'},
               'system': 'dwave-system',
               'embedding': 'dwave-system',
@@ -323,7 +324,7 @@ def linkcode_resolve(domain, info):
     # Based on https://github.com/numpy/numpy/blob/main/doc/source/conf.py
 
     if domain != 'py':
-        #f.write("\n NOT PY " + domain)
+        #f.write("\n  C: " + info['module'] + " -->" + info['fullname'])
         return None
 
     obj = sys.modules.get(info['module'])
@@ -331,7 +332,7 @@ def linkcode_resolve(domain, info):
         try:
             obj = getattr(obj, part)
         except Exception:
-            #f.write("\n Exception1: " + info['module'])
+            #f.write("\n  Exception1: " + info['module'] + " -->" + info['fullname'])
             return None
 
     # strip decorators, which would resolve to the source of the decorator
@@ -346,7 +347,7 @@ def linkcode_resolve(domain, info):
     try:
         fn = inspect.getsourcefile(obj)
     except Exception:
-        #f.write("\n Exception2: " + info['module'])
+        #f.write("\n  Exception2: " + info['module'] + " -->" + info['fullname'])
         return None
 
     try:
@@ -356,7 +357,7 @@ def linkcode_resolve(domain, info):
         lineno = ""
 
     if not fn or not "site-packages" in fn:
-       #f.write("\n NO FN: " + info['module'])
+       #f.write("\n  NO FN: " + info['module'] + " -->" + info['fullname'])
        return None
     
     if ".egg" in fn:
@@ -376,7 +377,7 @@ def linkcode_resolve(domain, info):
     else:
         fn = "https://github.com/dwavesystems/" + github_map[repo] + "/blob/master" + fn     
  
-    #f.write("\nNEW: " + fn + "  --> " + linespec)
+    #f.write("\nLink: " + fn + "  --> " + linespec)
 
     return fn + linespec
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -283,7 +283,7 @@ epub_exclude_files = ['search.html']
 # Example configuration for intersphinx: refer to the Python standard library.
 #intersphinx_mapping = {'https://docs.python.org/': None,
 #                       'http://networkx.readthedocs.io/en/latest/': None}
-intersphinx_mapping = {'python': ('https://docs.python.org/', None),
+intersphinx_mapping = {'python': ('https://docs.python.org/3/', None),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'bson': ('https://api.mongodb.com/python/current/', None),
     'networkx': ('https://networkx.github.io/documentation/stable/', None),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -394,13 +394,13 @@ def linkcode_resolve(domain, info):
     repo = target[1] if not target[1] == "dwave" else target[2]
 
     if repo == 'penaltymodel':
-        fn = "https://github.com/dwavesystems/penaltymodel/blob/" +  \
+        fn = "https://github.com/dwavesystems/penaltymodel/tree/" +  \
+             info['module'].split('.')[1] + "-" + \
              github_map['penaltymodel'][0][info['module'].split('.')[1]][1] + "/" + \
              github_map['penaltymodel'][0][info['module'].split('.')[1]][0] + fn
-
     else:
         fn = "https://github.com/dwavesystems/" + github_map[repo][0] + "/blob/" + \
-             github_map[repo][1] + "/" + fn     
+             github_map[repo][1] + fn     
  
     return fn + linespec
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -322,22 +322,21 @@ github_map = {'dwavebinarycsp': ['dwavebinarycsp',],
               'embedding': ['dwave-system',],
               'tabu': ['dwave-tabu',]}
 
-ocean_repos = {**{gh: repo[0] for gh, repo in github_map.items() if isinstance(repo[0], str)}, \
-               ** {gh: repo[0].replace('_', '-') for gh, repo in github_map['penaltymodel'][0].items()}} 
-
 os.system('cd .. ; python setup.py egg_info; cd docs')
-with open('../dwave_ocean_sdk.egg-info/requires.txt', 'r') as requires_file:
-    repo_info = requires_file.readlines()
-    for line in repo_info:
+with open('../dwave_ocean_sdk.egg-info/requires.txt', 'r') as requires_txt:
+    repo_versions = requires_txt.readlines()
+    for line in repo_versions:
         if line.split('==')[0] == 'penaltymodel':
             github_map['penaltymodel'][0]['core'].append(line.split('==')[1].rstrip())
-        for gh, repo in ocean_repos.items():
-            if repo in line:
-               if 'penaltymodel' in repo:
-                   github_map['penaltymodel'][0][gh].append(line.split('==')[1].rstrip())
-               else:
-                   github_map[gh].append(line.split('==')[1].rstrip())
-               #break  # not used because of embedding
+        for gh, repo in github_map.items():
+            if gh=='penaltymodel':
+               for gh, repo in repo[0].items():
+                  if repo[0].replace('_', '-') in line:
+                     github_map['penaltymodel'][0][gh].append(line.split('==')[1].rstrip())
+            else: # non penalty model
+               if repo[0] in line:
+                  github_map[gh].append(line.split('==')[1].rstrip())
+
 
 def linkcode_resolve(domain, info):
     """

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,11 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+# This file contains function linkcode_resolve, based on 
+# https://github.com/numpy/numpy/blob/main/doc/source/conf.py, 
+# which is licensed under the BSD 3-Clause "New" or "Revised" 
+# license: ./licenses/numpy.rst  
+
 import os
 import sys
 import subprocess

--- a/docs/licenses/numpy.rst
+++ b/docs/licenses/numpy.rst
@@ -1,0 +1,30 @@
+Copyright (c) 2005-2021, NumPy Developers.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the following
+  disclaimer in the documentation and/or other materials provided
+  with the distribution.
+
+* Neither the name of the NumPy Developers nor the names of any
+  contributors may be used to endorse or promote products derived
+  from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/licenses/sdk.rst
+++ b/docs/licenses/sdk.rst
@@ -3,3 +3,16 @@ dwave-ocean-sdk
 ===============
 
 .. include:: ../../LICENSE
+
+
+Documentation Build
+===================
+
+The `Sphinx conf.py <https://github.com/dwavesystems/dwave-ocean-sdk/blob/master/docs/conf.py>`_ 
+file used to build the SDK documentation contains some modified code from 
+https://github.com/numpy/numpy/blob/main/doc/source/conf.py, which is licensed
+under the BSD 3-Clause "New" or "Revised" license:
+
+.. include:: ./numpy.rst
+
+


### PR DESCRIPTION
Still needs a bit more work but before spending the time I'd like to get feedback on whether most people prefer such access to the GitHub code or to get the current HTML rendering. You can try it out here: https://sdk-docs.readthedocs.io/en/latest/ 

(@mcfarljm, re our discussion about the "Edit on GitHub" button not working for generated stubs.)

* Disadvantages: (1) extra complexity and will likely will need the occasional bit of maintenance (2) build time is a little longer
* Advantages: I find it very convenient to have one-click access to the source code

![image](https://user-images.githubusercontent.com/34041130/112844568-ba2d8800-9058-11eb-9f85-7ece0ac90542.png)

Here's what our docs currently do:
![image](https://user-images.githubusercontent.com/34041130/112844662-d29da280-9058-11eb-851a-a0316921a56d.png)

Here's how it work with this update:
![image](https://user-images.githubusercontent.com/34041130/112844829-037dd780-9059-11eb-996f-782026d6c405.png)
