### PR TITLE
Update cookie/theme-override methods in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,9 +180,9 @@ html_static_path = ['_static']
 #      }
 def setup(app):
    #app.add_javascript("custom.js")
-   app.add_stylesheet('theme_overrides.css')
-   app.add_stylesheet('cookie_notice.css')
-   app.add_javascript('cookie_notice.js')
+   app.add_css_file('theme_overrides.css')
+   app.add_css_file('cookie_notice.css')
+   app.add_js_file('cookie_notice.js')
    app.add_config_value('target', 'sdk', 'env')
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 penaltymodel-maxgap==0.5.4
 
-sphinx
+sphinx>=4.0.0,<5.0.0
 sphinx_rtd_theme
 recommonmark
 


### PR DESCRIPTION
`app.add_stylesheet()` and `app.add_javascript()` were renamed in version 1.8 and obsoleted in version 4