### PR TITLE
Use dimod gates in examples (1/2)

### DIFF
--- a/docs/overview/cpu.rst
+++ b/docs/overview/cpu.rst
@@ -16,16 +16,12 @@ Among several samplers provided in the :doc:`dimod </docs_dimod/sdk_index>`
 tool for testing your code locally, is the :class:`~dimod.reference.samplers.ExactSolver` 
 that calculates the energy of all
 possible samples for a given problem. Such a sampler can solve a small three-variable
-problem like the AND gate of the :ref:`formulating_bqm` section,
+problem such as a BQM representing a Boolean AND gate (see also the 
+:ref:`formulating_bqm` section) as follows:
 
->>> import dimod
->>> bqm = dimod.BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 6.0},
-...                  {('x2', 'x1'): 2.0, ('y1', 'x1'): -4.0, ('y1', 'x2'): -4.0},
-...                  0, 'BINARY')
-
-as follows:
-
->>> from dimod.reference.samplers import ExactSolver
+>>> from dimod.generators import and_gate
+>>> from dimod import ExactSolver
+>>> bqm = and_gate('x1', 'x2', 'y1')
 >>> sampler = ExactSolver()
 >>> response = sampler.sample(bqm)    
 >>> print(response)       # doctest: +SKIP

--- a/docs/overview/cpu.rst
+++ b/docs/overview/cpu.rst
@@ -21,19 +21,19 @@ problem such as a BQM representing a Boolean AND gate (see also the
 
 >>> from dimod.generators import and_gate
 >>> from dimod import ExactSolver
->>> bqm = and_gate('x1', 'x2', 'y1')
+>>> bqm = and_gate('in1', 'in2', 'out')
 >>> sampler = ExactSolver()
->>> response = sampler.sample(bqm)    
->>> print(response)       # doctest: +SKIP
-  x1 x2 y1 energy num_oc.
-0  0  0  0    0.0       1
-1  1  0  0    0.0       1
-3  0  1  0    0.0       1
-5  1  1  1    0.0       1
-2  1  1  0    2.0       1
-4  0  1  1    2.0       1
-6  1  0  1    2.0       1
-7  0  0  1    6.0       1
+>>> sampleset = sampler.sample(bqm)    
+>>> print(sampleset)       # doctest: +SKIP
+  in1 in2 out energy num_oc.
+0   0   0   0    0.0       1
+1   1   0   0    0.0       1
+3   0   1   0    0.0       1
+5   1   1   1    0.0       1
+2   1   1   0    2.0       1
+4   0   1   1    2.0       1
+6   1   0   1    2.0       1
+7   0   0   1    6.0       1
 ['BINARY', 8 rows, 8 samples, 3 variables]
 
 Note that the first four samples are the valid states of the AND gate and have

--- a/docs/overview/qpu.rst
+++ b/docs/overview/qpu.rst
@@ -12,11 +12,11 @@ that maps unstructured problems to the graph
 structure of the selected sampler, a process known as :term:`minor-embedding`.
 
 For a BQM representing a Boolean AND gate (see also the :ref:`formulating_bqm` 
-section) the problem is defined on alphanumeric variables :math:`x1, x2, y1` 
+section) the problem is defined on alphanumeric variables :math:`in1, in2, out` 
 that must be mapped to the QPU's numerically indexed qubits.
 
 >>> from dimod.generators import and_gate
->>> bqm = and_gate('x1', 'x2', 'y1')
+>>> bqm = and_gate('in1', 'in2', 'out')
 
 Because of the sampler's probabilistic nature, you typically request multiple samples
 for a problem; this example sets `num_reads` to 1000.
@@ -25,16 +25,16 @@ for a problem; this example sets `num_reads` to 1000.
 >>> sampler = EmbeddingComposite(DWaveSampler())
 >>> sampleset = sampler.sample(bqm, num_reads=1000)   
 >>> print(sampleset)   # doctest: +SKIP
-  x1 x2 y1 energy num_oc. chain_b.
-0  1  0  0    0.0     321      0.0
-1  1  1  1    0.0      97      0.0
-2  0  0  0    0.0     375      0.0
-3  0  1  0    0.0     206      0.0
-4  1  0  1    2.0       1 0.333333
+  in1 in2 out energy num_oc. chain_.
+0   1   0   0    0.0     321     0.0
+1   1   1   1    0.0      97     0.0
+2   0   0   0    0.0     375     0.0
+3   0   1   0    0.0     206     0.0
+4   1   0   1    2.0       1 0.33333
 ['BINARY', 5 rows, 1000 samples, 3 variables]
 
 Note that the first four samples are the valid states of the AND gate and have
-lower energy than invalid state :math:`x1=1, x2=0, y1=1`.
+lower energy than invalid state :math:`in1=1, in2=0, out=1`.
 
 Once you have configured a
 :doc:`D-Wave Cloud Client configuration file </docs_cloud/sdk_index>` as described in

--- a/docs/overview/qpu.rst
+++ b/docs/overview/qpu.rst
@@ -10,16 +10,13 @@ you to use a D-Wave system as a sampler. In addition to
 provides a :class:`~dwave.system.composites.EmbeddingComposite` composite 
 that maps unstructured problems to the graph
 structure of the selected sampler, a process known as :term:`minor-embedding`.
-For the AND gate of the :ref:`formulating_bqm` section, 
 
->>> import dimod
->>> bqm = dimod.BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 6.0},
-...                  {('x2', 'x1'): 2.0, ('y1', 'x1'): -4.0, ('y1', 'x2'): -4.0},
-...                  0, 'BINARY')
+For a BQM representing a Boolean AND gate (see also the :ref:`formulating_bqm` 
+section) the problem is defined on alphanumeric variables :math:`x1, x2, y1` 
+that must be mapped to the QPU's numerically indexed qubits.
 
-the problem is defined on
-alphanumeric variables :math:`x1, x2, y1`, that must be mapped to the QPU's numerically
-indexed qubits.
+>>> from dimod.generators import and_gate
+>>> bqm = and_gate('x1', 'x2', 'y1')
 
 Because of the sampler's probabilistic nature, you typically request multiple samples
 for a problem; this example sets `num_reads` to 1000.

--- a/docs/overview/samplers.rst
+++ b/docs/overview/samplers.rst
@@ -29,25 +29,21 @@ compute resources (:term:`solver`\ s) of different types:
   exact solutions to small problems
 * :ref:`using_qpu` such the Advantage and D-Wave 2000Q systems.
 
-The example code below submits the BQM of the AND gate of the :ref:`formulating_bqm` section,
-
->>> import dimod
->>> bqm = dimod.BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 6.0},
-...                  {('x2', 'x1'): 2.0, ('y1', 'x1'): -4.0, ('y1', 'x2'): -4.0},
-...                  0, 'BINARY')
-
-to a Leap hybrid solver.
+The example code below submits a BQM representing a Boolean AND gate (see also the
+:ref:`formulating_bqm` section) to a Leap hybrid solver.
 In this case, :doc:`dwave-system </docs_system/sdk_index>`'s
 :class:`~dwave.system.samplers.LeapHybridSampler` is the Ocean sampler and the
 remote compute resource selected might be Leap hybrid solver 
 ``hybrid_binary_quadratic_model_version<x>``.
 
+>>> from dimod.generators import and_gate
 >>> from dwave.system import LeapHybridSampler
+>>> bqm = and_gate('x1', 'x2', 'y1')
 >>> sampler = LeapHybridSampler()    # doctest: +SKIP
 >>> answer = sampler.sample(bqm)   # doctest: +SKIP
 >>> print(answer)    # doctest: +SKIP
-x1 x2 y1 energy num_oc.
-0  0  1  0    0.0       1
+  x1 x2 y1 energy num_oc.
+0  1  1  1    0.0       1
 ['BINARY', 1 rows, 1 samples, 3 variables]
 
 .. _improving:

--- a/docs/overview/solving_problems.rst
+++ b/docs/overview/solving_problems.rst
@@ -105,21 +105,18 @@ The following are two example formulations.
       :math:`1`    :math:`1`     No               :math:`1`
       ===========  ============  ===============  ============
 
-2. Ocean's :doc:`dwavebinarycsp </docs_binarycsp/sdk_index>` tool enables the
+2. Ocean's :doc:`dimod </docs_dimod/sdk_index>` tool enables the
    following formulation of an AND gate as a BQM:
 
->>> import dwavebinarycsp
->>> import dwavebinarycsp.factories.constraint.gates as gates
->>> csp = dwavebinarycsp.ConstraintSatisfactionProblem(dwavebinarycsp.BINARY)
->>> csp.add_constraint(gates.and_gate(['x1', 'x2', 'y1']))  # add an AND gate
->>> bqm = dwavebinarycsp.stitch(csp)
+>>> from dimod.generators import and_gate
+>>> bqm = and_gate('x1', 'x2', 'y1')
 
-The resultant BQM of this AND gate may look like this:
+The BQM for this AND gate may look like this:
 
 >>> bqm     # doctest: +SKIP
-BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 6.0},
-...                  {('x2', 'x1'): 2.0, ('y1', 'x1'): -4.0, ('y1', 'x2'): -4.0},
-...                  0,
+BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 3.0}, 
+...                  {('x2', 'x1'): 1.0, ('y1', 'x1'): -2.0, ('y1', 'x2'): -2.0}, 
+...                  0.0, 
 ...                  'BINARY')
 
 The members of the two dicts are linear and quadratic coefficients, respectively,

--- a/docs/overview/solving_problems.rst
+++ b/docs/overview/solving_problems.rst
@@ -109,13 +109,13 @@ The following are two example formulations.
    following formulation of an AND gate as a BQM:
 
 >>> from dimod.generators import and_gate
->>> bqm = and_gate('x1', 'x2', 'y1')
+>>> bqm = and_gate('in1', 'in2', 'out')
 
 The BQM for this AND gate may look like this:
 
 >>> bqm     # doctest: +SKIP
-BinaryQuadraticModel({'x1': 0.0, 'x2': 0.0, 'y1': 3.0}, 
-...                  {('x2', 'x1'): 1.0, ('y1', 'x1'): -2.0, ('y1', 'x2'): -2.0}, 
+BinaryQuadraticModel({'in1': 0.0, 'in2': 0.0, 'out': 3.0}, 
+...                  {('in2', 'in1'): 1.0, ('out', 'in1'): -2.0, ('out', 'in2'): -2.0}, 
 ...                  0.0, 
 ...                  'BINARY')
 


### PR DESCRIPTION
Requires dimod 0.10.x. This PR replaces uses of `dwavebinarycsp.factories.constraint.gates` when used only to provide a Boolean gate, not when dwavebinarycsp is used for additional constraint creation. 