### PR TITLE
Prevent linkcheck fail on dimod

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,7 @@ add_module_names = False
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 linkcheck_ignore=[r'.clang-format',                   # would need symlink
+                  r'setup.cfg',                       # would need symlink (for dimod)
                   r'https://cloud.dwavesys.com/leap', # redirects, many checks
                   r'https://scipy.org',               # ignores robots
                   r'LICENSE',                         # would need symlink, checked by submodule


### PR DESCRIPTION
Commit https://github.com/dwavesystems/dimod/commit/ee8f7ecf1ab638f02a4e0099456edad256bd0775 added ``setup.cfg <setup.cfg>`_` that will cause a linkcheck failure when used as a submodule of the SDK (it's a symlink):

```
(docs_dimod/README: line   92) broken    setup.cfg - 
```
