### PR TITLE
Update PyQUBO to 1.1.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     penaltymodel-mip==0.2.5; platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64"
     penaltymodel-lp==0.1.5
     penaltymodel==0.16.5
-    pyqubo==1.0.13
+    pyqubo==1.1.0
 packages = dwaveoceansdk
 python_requires = >=3.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     penaltymodel-mip==0.2.6; platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64"
     penaltymodel-lp==0.1.6
     penaltymodel==0.16.6
-    pyqubo==1.1.2; python_version < "3.10"
+    pyqubo==1.1.2;python_version < "3.10"
 packages = dwaveoceansdk
 python_requires = >=3.6
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     penaltymodel-mip==0.2.5; platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64"
     penaltymodel-lp==0.1.5
     penaltymodel==0.16.5
-    pyqubo==1.1.0
+    pyqubo==1.1.2
 packages = dwaveoceansdk
 python_requires = >=3.6
 


### PR DESCRIPTION
PyQUBO is updated so that it contains wheels for Apple Silicon.
https://github.com/recruit-communications/pyqubo/releases/tag/1.1.0
