### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,6 @@ environment:
 
     # https://www.appveyor.com/docs/build-environment/#python
 
-    - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
     - PYTHON: "C:\\Python39-x64"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              python-version: &python-versions ["3.6.8", "3.7.9", "3.8.9", "3.9.4", "3.10.0"]
+              python-version: &python-versions ["3.7.9", "3.8.9", "3.9.4", "3.10.0"]
       - test-macos:
           matrix:
             parameters:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -46,7 +45,7 @@ install_requires =
     penaltymodel==0.16.6
     pyqubo==1.2.0
 packages = dwaveoceansdk
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.extras_require]
 all =


### PR DESCRIPTION
I think that's all of the places, we dropped it from the README.