### PR TITLE
Fix black-duck test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,26 +209,21 @@ jobs:
     docker:
       - image: circleci/openjdk:8-jdk-browsers
 
-    working_directory: ~/repo
-
     steps:
       - checkout
 
       - run:
-          name: install python3
+          name: install python
           command: |
             sudo apt-get update
             sudo apt-get install build-essential
-            sudo apt-get install python3 python3-pip python3-dev python3-virtualenv
+            sudo apt-get install python3 python3-pip python3-dev python3-virtualenv python3-venv
 
       - run:
           name: create virtual env
           command: |
-            python3 -m venv env -p python3
-
-      - run:
-          name: install package
-          command: |
+            python3 --version
+            python3 -m venv env
             . env/bin/activate
             pip install .
 


### PR DESCRIPTION
Needs `virtualenv` for the blackduck script itself. And then we use `venv` :shrug:.