### PR TITLE
Update penaltymodel to 1.0.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     dwave-tabu==0.4.4
     dwavebinarycsp==0.2.0
     minorminer==0.2.7.post0
-    penaltymodel==1.0.1
+    penaltymodel==1.0.2
     pyqubo==1.2.0
 packages = dwaveoceansdk
 python_requires = >=3.7


### PR DESCRIPTION
Resolves the sporadic `dwavebinarycsp` CI failures