### PR TITLE
Fix minorminer C build for docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -119,6 +119,7 @@ breathe_projects = {"minorminer": os.path.join(
                     }
 
 breathe_default_members = ('members', )
+breathe_default_project = "minorminer"
 
 # we want to build the c++ docs in RTD
 if os.environ.get('READTHEDOCS', False):


### PR DESCRIPTION
Fixes C build problems for minorminer such as https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/source/cpp/namespace/namespacebusclique.html: 
![image](https://user-images.githubusercontent.com/34041130/168104664-d64a1f8a-9678-479a-89ae-13df5a128b83.png)

https://sdk-docs.readthedocs.io/en/latest/docs_minorminer/source/reference/cppdocs.html

Does not aversely affect preprocessing & dimod

