### PR TITLE
Update PyQUBO version to 1.3.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     dwavebinarycsp==0.2.0
     minorminer==0.2.9
     penaltymodel==1.0.2
-    pyqubo==1.3.0
+    pyqubo==1.3.1
 packages = dwaveoceansdk
 python_requires = >=3.7
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     dwavebinarycsp==0.2.0
     minorminer==0.2.9
     penaltymodel==1.0.2
-    # pyqubo==1.2.0
+    pyqubo==1.3.0
 packages = dwaveoceansdk
 python_requires = >=3.7
 


### PR DESCRIPTION
PyQUBO version 1.3.0 is released. This version is compatible with dimod 0.11.x.
https://github.com/recruit-communications/pyqubo/releases/tag/1.3.0