### PR TITLE
Update PyQUBO version to support Python 3.11

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ install_requires =
     dwavebinarycsp==0.2.0
     minorminer==0.2.9
     penaltymodel==1.0.2
-    pyqubo==1.3.1
+    pyqubo==1.4.0
 packages = dwaveoceansdk
 python_requires = >=3.7
 


### PR DESCRIPTION
I updated PyQUBO to support Python 3.11 in the latest version (1.4.0). I'd appreciate it if you could take a look. Thank you!