### PR TITLE
Migrate from CircleCI scheduled workflows to pipelines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -290,13 +290,8 @@ workflows:
               configuration: [--detect.project.version.phase=RELEASED]
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      equal: [nightly, << pipeline.schedule.name >>]
     jobs:
       - test-linux:
           matrix:


### PR DESCRIPTION
Scheduled workflows have been deprecated, and then deprecation postponed 2 months ago.

Regardless of (un)deprecation, "scheduled pipelines" (with triggers defined separately from config.yml) remain the only way to execute a workflow on schedule in a restricted security context.