### PR TITLE
Fix RTD YAML file for dwave-gate

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,6 +12,7 @@ python:
    install:
       - method: pip
         path: .
+        extra_requirements: [all]
       - requirements: docs/requirements.txt
         
 


### PR DESCRIPTION
Since the [dwave-gate docs PR](https://github.com/dwavesystems/dwave-ocean-sdk/pull/247), the doc build is failing with ``IndexError: list index out of range`` error on line [this line of conf.py](https://github.com/dwavesystems/dwave-ocean-sdk/blob/e62df3842f80bbc08cc4a8f000927ee3e8426ef9/docs/conf.py#L209). I think this should fix it.

The ``conf.py`` file might benefit from also being updated to use [importlib.resources, importlib.metadata](https://setuptools.pypa.io/en/latest/pkg_resources.html) instead of ``pkg_resources`` at some point, as noted therr.