### PR TITLE
Refresh the contributing guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,7 +59,7 @@ Coding Conventions
 * Functions should do one thing.
 * Early pull requests and code reviews.
 * Early architecting/design. Code reviews can happen before any code has been written.
-* Use a consistent character width of 120.
+* Use a consistent character width limit of 120.
 * Use 4 spaces instead of tabs.
 * End all files with a newline.
 
@@ -103,10 +103,20 @@ Documentation and Comments
 Python
 ------
 
+Python Version
+~~~~~~~~~~~~~~
+
+Code should be compatible with all `supported versions <https://devguide.python.org/versions/#supported-versions>`_
+of Python.
+
 pep8
 ~~~~
 
 As a baseline, follow the `pep8 <https://www.python.org/dev/peps/pep-0008/>`_ style guide for python.
+
+We do make one exception for `maximum line length <https://peps.python.org/pep-0008/#maximum-line-length>`_.
+In Ocean we maintain a hard limit of 120 characters. It is encouraged but not required to keep lines of code
+to 100 characters or fewer and docstrings/comments to 72 characters or fewer.
 
 Documentation
 ~~~~~~~~~~~~~
@@ -131,18 +141,38 @@ C++
 C++ Version
 ~~~~~~~~~~~
 
-C++ code should be compatible with standard C++11.
+C++ code should be compatible with standard C++17.
+
+See `PyPA's docs <https://cibuildwheel.readthedocs.io/en/stable/cpp_standards/>`_ on C++ standards for a discussion
+on how this interacts with Python wheels.
 
 Format
 ~~~~~~
 
 * Our format is based on `Google C++ style guide <https://google.github.io/styleguide/cppguide.html>`_ with some exceptions:
 
-  - Column width is limited to 120 characters. Best effort should be made to keep to 80 characters, but up to 120 can be used for clarity.
+  - Column width is limited to 100 characters. Best effort should be made to keep to 80 characters, but up to 120 can be used for clarity.
   - The base indent level is 4.
   - Non-const references are allowed.
 
-* When starting a new C++ project, use clang-format with the `.clang-format <.clang-format>`_ file included here.
+* When starting a new C++ project, use a `.clang-format` file
+
+.. code-block::
+
+  ---
+  Language: Cpp
+  BasedOnStyle: Google
+
+  ColumnLimit: 100
+  NamespaceIndentation: None
+
+  # Scaled by a factor of 2 such that the base indent is 4
+  AccessModifierOffset: -3
+  IndentWidth: 4
+  ContinuationIndentWidth: 8
+  ConstructorInitializerIndentWidth: 8
+  ...
+
 
 Versioning Scheme
 -----------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,7 +59,7 @@ Coding Conventions
 * Functions should do one thing.
 * Early pull requests and code reviews.
 * Early architecting/design. Code reviews can happen before any code has been written.
-* Use a consistent character width limit of 120.
+* Use a consistent character limit of 100.
 * Use 4 spaces instead of tabs.
 * End all files with a newline.
 
@@ -88,7 +88,8 @@ Documentation and Comments
 
   .. code-block:: python
 
-    # if z is greater than 255, this universe will collapse. See https://url.to.issue.tracker/IS-42
+    # If z is greater than 255, this universe will collapse.
+    # See https://url.to.issue.tracker/IS-42
     if z > 255:
         raise RuntimeError('z must be <= 255!')
 
@@ -106,8 +107,8 @@ Python
 Python Version
 ~~~~~~~~~~~~~~
 
-Code should be compatible with all `supported versions <https://devguide.python.org/versions/#supported-versions>`_
-of Python.
+Code should be compatible with all `supported versions <https://devguide.python.org/versions/>`_
+of Python. Specifically, versions of Python that have "bugfix" or "security" status.
 
 pep8
 ~~~~
@@ -151,7 +152,7 @@ Format
 
 * Our format is based on `Google C++ style guide <https://google.github.io/styleguide/cppguide.html>`_ with some exceptions:
 
-  - Column width is limited to 100 characters. Best effort should be made to keep to 80 characters, but up to 120 can be used for clarity.
+  - Column width is limited to 100 characters. Best effort should be made to keep to 80 characters, but up to 100 can be used for clarity.
   - The base indent level is 4.
   - Non-const references are allowed.
 


### PR DESCRIPTION
Closes https://github.com/dwavesystems/dwave-ocean-sdk/issues/89

Obviously there is much here that can be debated. I tried to err on the side of clarifying existing conventions rather than adding new ones.

The biggest change is in the C++ section. In that case I included the `.clang-format` file we're currently using in [dimod](https://github.com/dwavesystems/dimod/blob/main/.clang-format) and [dwave-preprocessing](https://github.com/dwavesystems/dwave-preprocessing/blob/main/.clang-format). [minorminer](https://github.com/dwavesystems/minorminer/blob/main/.clang-format) uses a similar one but uses a 120 character limit.
I have a weak preference for the 100 character limit, but am fine either way.