### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,10 +4,10 @@ environment:
 
     # https://www.appveyor.com/docs/build-environment/#python
 
-    - PYTHON: "C:\\Python37-x64"
     - PYTHON: "C:\\Python38-x64"
     - PYTHON: "C:\\Python39-x64"
     - PYTHON: "C:\\Python310-x64"
+    - PYTHON: "C:\\Python311-x64"
 
 install:
   - "%PYTHON%\\python.exe --version"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
 
   test-doctest:
     docker:
-      - image: cimg/python:3.7 # as of march 2019 RTD uses 3.7
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 
@@ -178,7 +178,7 @@ jobs:
 
   deploy:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
 
     working_directory: ~/repo
 
@@ -273,7 +273,7 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              python-version: &python-versions ["3.7.9", "3.8.9", "3.9.4", "3.10.0", "3.11.0"]
+              python-version: &python-versions ["3.8.9", "3.9.4", "3.10.0", "3.11.0"]
       - test-macos:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
                 pip install -r "$subdir"/requirements_dev.txt
               fi
               done
-            pip install cython wheel cgen
+            pip install 'cython<3' wheel cgen
             pip install .[all]
             dwave install --all --yes
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
     executor:
       name: ocean/macos
-      xcode: "13.2.0"
+      xcode: "14.2.0"
 
     steps:
       - checkout

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,9 @@ Stack Overflow provides an excellent guide on [how to create a Minimal, Complete
 A clear and concise description of what you expected to happen.
 
 **Environment:**
- - OS: [Ubuntu 16.04.4 LTS]
- - Python version: [e.g. 3.7.0]
+ - OS: [e.g. Ubuntu 20.04.6 LTS]
+ - Python version: [e.g. 3.11.0]
+ - Ocean SDK version: [e.g. 6.4.0]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ sphinx:
     configuration: docs/conf.py
 
 python:
-   version: 3.7
+   version: 3.8
    install:
       - method: pip
         path: .

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,6 @@ classifiers =
     License :: OSI Approved :: Apache Software License
     Operating System :: OS Independent
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -42,7 +41,7 @@ install_requires =
     penaltymodel==1.0.2
     pyqubo==1.4.0
 packages = dwaveoceansdk
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 all =


### PR DESCRIPTION
- drop py37
- upgrade xcode to fix CircleCI macos builds on the medium resource class
- upper-bound cython (long term we'll have to upgrade to cython 3, which is finally out)