### PR TITLE
Update rtd.yml for build fail on ``"build.os": build not found``

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,11 +8,14 @@ sphinx:
     configuration: docs/conf.py
 
 python:
-   version: 3.8
    install:
       - method: pip
         path: .
         extra_requirements: [all]
       - requirements: docs/requirements.txt
         
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
 


### PR DESCRIPTION
Get the RTD build passing, then look into any other config/yml updates that might be helpful. See [here](https://blog.readthedocs.com/use-build-os-config/) for why build fails.