### PR TITLE
WIP: Update doc-build tools to support new ``pydata-sphinx-theme`` & switch from obsolete ``sphinx-panels``

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -21,19 +21,51 @@
     font-weight:    normal !important; 
 }
 
-:root {
+html[data-theme="light"] {
     /* dwave colors for convenience */
-    --dwave-color-ocean-blue: 42, 125, 225;
-    --dwave-color-dark-blue: 7, 76, 145;
-    --dwave-color-bright-blue: 3, 184, 255;
+    --dwave-color-ocean-blue: rgb(42, 125, 225);
+    --dwave-color-dark-blue: rgb(7, 76, 145);
+    --dwave-color-bright-blue: rgb(3, 184, 255);
 
-    --dwave-color-leap-teal: 23, 190, 187;
-    --dwave-color-dark-teal: 0, 140, 130;
-    --dwave-color-bright-teal: 6, 236, 220;
+    --dwave-color-leap-teal: rgb(23, 190, 187);
+    --dwave-color-dark-teal: rgb(0, 140, 130);
+    --dwave-color-bright-teal: rgb(6, 236, 220);
 
-    --dwave-color-advantage-orange: 243, 120, 32;
-    --dwave-color-dark-orange: 175, 73, 4;
-    --dwave-color-bright-orange: 255, 161, 67;
+    --dwave-color-advantage-orange: rgb(243, 120, 32);
+    --dwave-color-dark-orange: rgb(175, 73, 4);
+    --dwave-color-bright-orange: rgb(255, 161, 67);
+
+    /* theme overrides */
+    --pst-color-primary: rgb(34, 34, 34);
+    --pst-color-link: var(--dwave-color-ocean-blue);
+    --pst-color-link-hover: var(--dwave-color-dark-blue);
+    /*--pst-color-inline-code: var(--dwave-color-advantage-sienna);*/
+    --pst-color-success: var(--dwave-color-leap-teal);
+    --pst-color-info: var(--dwave-color-ocean-blue);
+    --pst-color-warning: var(--dwave-color-advantage-orange);
+    /*--pst-color-danger: 220, 53, 69;*/
+    --pst-color-active-navigation: var(--dwave-color-ocean-blue);
+    --pst-color-navbar-link-hover: var(--dwave-color-ocean-blue);
+    --pst-color-navbar-link-active: var(--dwave-color-ocean-blue);
+    --pst-color-sidebar-link-hover: var(--dwave-color-ocean-blue);
+    --pst-color-sidebar-link-active: var(--dwave-color-ocean-blue);
+    --pst-color-toc-link-hover: var(--dwave-color-ocean-blue);
+    --pst-color-toc-link-active: var(--dwave-color-ocean-blue);
+}
+
+html[data-theme="dark"] {
+    /* dwave colors for convenience */
+    --dwave-color-ocean-blue: rgb(42, 125, 225);
+    --dwave-color-dark-blue: rgb(7, 76, 145);
+    --dwave-color-bright-blue: rgb(3, 184, 255);
+
+    --dwave-color-leap-teal: rgb(23, 190, 187);
+    --dwave-color-dark-teal: rgb(0, 140, 130);
+    --dwave-color-bright-teal: rgb(6, 236, 220);
+
+    --dwave-color-advantage-orange: rgb(243, 120, 32);
+    --dwave-color-dark-orange: rgb(175, 73, 4);
+    --dwave-color-bright-orange: rgb(255, 161, 67);
 
     /* theme overrides */
     --pst-color-primary: 34, 34, 34;

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -10,10 +10,15 @@
     overflow: visible;
 }
 
-/* subclass Bootstrap4 badges */
-.badge-primary.fr, .badge-secondary.fr {
-  float: right;
-  margin-left: 0.25rem;
+/* Bootstrap badges */
+.sd-badge {
+    float: right;
+    margin-left: 0.25rem;
+}
+
+/* Dropdown titles */
+.sd-summary-title{
+    font-weight:    normal !important; 
 }
 
 :root {

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -10,15 +10,15 @@
     overflow: visible;
 }
 
-/* Bootstrap badges */
+/* Bootstrap badges NOT YET WORKING*/
 .sd-badge {
-    float: right;
-    margin-left: 0.25rem;
+    float: right !important;
 }
 
-/* Dropdown titles */
+/* Dropdown titles NOT YET WORKING: aligned text*/
 .sd-summary-title{
-    font-weight:    normal !important; 
+    font-weight:    normal !important;
+    text-align: left !important; 
 }
 
 html[data-theme="light"] {
@@ -36,7 +36,8 @@ html[data-theme="light"] {
     --dwave-color-bright-orange: rgb(255, 161, 67);
 
     /* theme overrides */
-    --pst-color-primary: rgb(34, 34, 34);
+    --pst-color-primary: var(--dwave-color-ocean-blue);
+    --pst-color-secondary: grey;
     --pst-color-link: var(--dwave-color-ocean-blue);
     --pst-color-link-hover: var(--dwave-color-dark-blue);
     /*--pst-color-inline-code: var(--dwave-color-advantage-sienna);*/
@@ -68,7 +69,8 @@ html[data-theme="dark"] {
     --dwave-color-bright-orange: rgb(255, 161, 67);
 
     /* theme overrides */
-    --pst-color-primary: 34, 34, 34;
+    --pst-color-primary: var(--dwave-color-ocean-blue);
+    --pst-color-secondary: grey;
     --pst-color-link: var(--dwave-color-ocean-blue);
     --pst-color-link-hover: var(--dwave-color-dark-blue);
     /*--pst-color-inline-code: var(--dwave-color-advantage-sienna);*/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,6 +159,8 @@ html_theme_options = {
         },
     ],
     "collapse_navigation": True,
+    "header_links_before_dropdown": 8,
+    "navbar_align": "right",  
     "show_prev_next": False,
     "logo": {
         "image_light": "_static/DWave-Ocean.svg",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,7 @@ copyright = setup_cfg['metadata']['author']
 project = 'Ocean Documentation'
 
 # Also add our own 'special value', the minimum supported Python version
-rst_prolog = f" .. |python_requires| replace:: {setup_cfg['options']['python_requires']}"
+# rst_prolog = f" .. |python_requires| replace:: {setup_cfg['options']['python_requires']}"
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -160,12 +160,15 @@ html_theme_options = {
     ],
     "collapse_navigation": True,
     "show_prev_next": False,
+    "logo": {
+        "image_light": "_static/DWave-Ocean.svg",
+        "image_dark": "_static/DWave-Ocean.svg",
+    }
 }
 html_sidebars = {
     "**": ["search-field", "sidebar-nav-bs"]  # remove ads
 }
 html_static_path = ['_static']
-
 
 def setup(app):
    app.add_css_file('theme_overrides.css')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.ifconfig',
     'breathe',
-    'sphinx_panels',
+    'sphinx_design',
     'reno.sphinxext',
     'sphinx_copybutton',
 ]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,55 +28,55 @@ Packages
 ========
 
 The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
-
+   
 .. packages-start-marker
 
 .. dropdown::  **dimod** --- Quadratic models: BQM, DQM. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_dimod/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dimod, "code", cls=badge-secondary fr text-white`
-
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_dimod/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dimod>` 
+ 
    Shared API for binary quadratic :term:`sampler`\ s. Provides a binary quadratic model (BQM) class
    that contains :term:`Ising` and quadratic unconstrained binary optimization (:term:`QUBO`) models
    used by samplers such as the D-Wave system. Also provides utilities for constructing new samplers
    and composed samplers.
 
 .. dropdown:: **dwavebinarycsp** --- Generates BQMs from constraint satisfaction problems. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_binarycsp/sdk_index.html,"docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwavebinarycsp,"code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_binarycsp/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwavebinarycsp>`
 
    Library to construct a binary quadratic model from a constraint satisfaction
    problem with small constraints over binary variables.
 
 .. dropdown:: **dwave-cloud-client** --- API client to D-Wave solvers. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_cloud/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-cloud-client, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_cloud/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-cloud-client>`
 
    Minimal implementation of the REST interface used to communicate with D-Wave
    :term:`Sampler` API (SAPI) servers.
 
 .. dropdown:: **dwave-gate** --- Package for quantum circuits. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_gate/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-gate, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_gate/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-gate>`
 
    A software package for constructing, modifying and running quantum circuits.
 
 .. dropdown:: **dwave-hybrid** --- Framework for building hybrid solvers. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_hybrid/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-hybrid, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_hybrid/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-hybrid>`
 
    A general, minimal Python framework for building hybrid asynchronous decomposition
    samplers for quadratic unconstrained binary optimization (QUBO) problems.
 
 .. dropdown:: **dwave-inspector** --- Visualizer for problems submitted to quantum computers. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_inspector/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-inspector, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_inspector/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-inspector>`
 
    A tool for visualizing problems submitted to, and answers received from, a D-Wave
    structured solver such as a D-Wave 2000Q quantum computer.
 
 .. dropdown:: **dwave-networkx** --- NetworkX extension. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_dnx/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-networkx, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_dnx/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-networkx>`
 
    Extension of NetworkX—a Python language package for exploration and analysis
    of networks and network algorithms—for users of D-Wave Systems.
@@ -86,20 +86,20 @@ The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
    binary quadratic model :term:`sampler`\ s.
 
 .. dropdown:: **dwave-ocean-sdk** --- Ocean software development kit. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-ocean-sdk, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-ocean-sdk>`
 
    Installer for D-Wave's Ocean Tools.
 
 .. dropdown:: **dwave-preprocessing** --- Preprocessing tools for quadratic models. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_preprocessing/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-preprocessing, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_preprocessing/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-preprocessing>`
 
    Library containing common preprocessing tools for quadratic models.
 
 .. dropdown:: **dwave-samplers** --- Classical algorithms for solving binary quadratic models. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_samplers/index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-samplers, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_samplers/index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-samplers>`
 
    A library that implements the following classical algorithms as :term:`samplers<sampler>` for solving
    :term:`binary quadratic models<BQM>` (BQM):
@@ -114,8 +114,8 @@ The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
    * Tree Decomposition: an exact solver for problems with low treewidth.
 
 .. dropdown:: **dwave-system** --- D-Wave samplers and composites. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_system/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/dwave-system, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_system/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/dwave-system>`
 
    Basic API for easily incorporating the D-Wave system as a :term:`sampler` in the
    D-Wave Ocean software stack.
@@ -126,8 +126,8 @@ The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
    can be used with DWaveSampler to handle :term:`minor-embedding`, optimize chain strength, etc.
 
 .. dropdown:: **minorminer** --- Minor-embeds graphs. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/source/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/minorminer, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/source/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/minorminer>`
 
    A tool for finding graph :term:`minor-embedding`\ s, developed to embed :term:`Ising` problems onto quantum annealers (QA).
 
@@ -136,8 +136,8 @@ The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
    and hardware graphs of a few thousand qubits.
 
 .. dropdown:: **penaltymodel** --- Maps constraints to binary quadratic models. \
-   :link-badge:`https://docs.ocean.dwavesys.com/en/stable/docs_penalty/sdk_index.html, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/dwavesystems/penaltymodel, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://docs.ocean.dwavesys.com/en/stable/docs_penalty/sdk_index.html>` \
+   :bdg-link-secondary:`code <https://github.com/dwavesystems/penaltymodel>`
 
    An approach to solve a constraint satisfaction problem (CSP) using an :term:`Ising`
    model or a :term:`QUBO`, is to map each individual constraint in the CSP to a ‘small’
@@ -147,8 +147,8 @@ The Ocean SDK includes the :ref:`dwave_cli` and the following packages:
    using SMT solvers.
 
 .. dropdown:: **pyqubo** --- Creates quadratic models from mathematical expressions. \
-   :link-badge:`https://pyqubo.readthedocs.io/en/latest, "docs", cls=badge-primary fr text-white` \
-   :link-badge:`https://github.com/recruit-communications/pyqubo, "code", cls=badge-secondary fr text-white`
+   :bdg-link-primary:`docs <https://pyqubo.readthedocs.io/en/latest>` \
+   :bdg-link-secondary:`code <https://github.com/recruit-communications/pyqubo>`
 
    A package that helps you create QUBOs and Ising models from flexible mathematical expressions.
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-pydata-sphinx-theme==0.14.0
+pydata-sphinx-theme==0.14.3
 sphinx==7.2.6
 sphinx-design==0.5.0
 sphinx-copybutton==0.5.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-pydata-sphinx-theme==0.8.0
-sphinx==5.1.0
+pydata-sphinx-theme==0.14.0
+sphinx==7.2.6
 sphinx-design==0.5.0
 sphinx-copybutton==0.5.0
 reno[sphinx]==3.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,6 @@
 pydata-sphinx-theme==0.8.0
-sphinx==4.4.0
-docutils==0.16  # docutils ~=0.17 causes some issues and sphinx 4.4.0 does not support newer
-sphinx-panels==0.6.0
+sphinx==5.1.0
+sphinx-design==0.5.0
 sphinx-copybutton==0.5.0
 reno[sphinx]==3.3.0
 


### PR DESCRIPTION
I'll open this WIP now but will continue after my PTO. I've fixed the worst of the backwards incompatibilities but still need to 

- Fix the ``rst_prolog = f" .. |python_requires| replace:: {setup_cfg['options']['python_requires']}"``, which is currently commented out (it otherwise adds a blank line at the top of every page) 
- get the badges to float right on the index page (I think the class's use of ``::before`` makes the float not work)
- ``docs/_static/theme_overrides.css`` can definitely be shortened, I just duplicated for now
- clean up a bit from my testing and old stuff 

Notice that the theme now supports dark mode. A future PR can set a different color scheme more suitable for dark mode.
![image](https://github.com/dwavesystems/dwave-ocean-sdk/assets/34041130/48190085-32b6-43a3-ada7-976d07b68e18)
