### PR TITLE
Add favicon

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,6 +138,11 @@ if os.environ.get('READTHEDOCS', False):
 html_theme = 'pydata_sphinx_theme'
 html_logo = "_static/DWave-Ocean.svg"
 
+# Temporary for current pydata_sphinx_theme==0.8. Will update per
+# https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/branding.html#add-favicons
+# when https://github.com/dwavesystems/dwave-ocean-sdk/pull/274 is merged 
+html_favicon = 'https://www.dwavesys.com/favicon.ico'
+
 html_theme_options = {
     "github_url": "https://github.com/dwavesystems/dwave-ocean-sdk",
     "external_links": [


### PR DESCRIPTION
In case we release a new SDK before the [doc-build tools PR](https://github.com/dwavesystems/dwave-ocean-sdk/pull/274) is merged.

* Currently:
![image](https://github.com/dwavesystems/dwave-ocean-sdk/assets/34041130/6c350aa1-a8db-49f9-966f-1d66931a99a0)

* New:
![image](https://github.com/dwavesystems/dwave-ocean-sdk/assets/34041130/ebd5a0be-7fbc-464e-a8bf-32dbd5e18621)
