### PR TITLE
Update docs build system for python 3.12

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,9 @@ import os
 import sys
 import subprocess
 import inspect
-import pkg_resources
+
+from importlib.metadata import Distribution
+from packaging.requirements import Requirement
 
 sdk_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -213,9 +215,9 @@ github_map = {'dwavebinarycsp': 'dwavebinarycsp',
               'embedding': 'dwave-system',
               'tabu': 'dwave-tabu'}
 
-reqs = pkg_resources.get_distribution('dwave-ocean-sdk').requires(extras=['all'])
-pkgs = [pkg_resources.get_distribution(req) for req in reqs]
-versions = {pkg.project_name: pkg.version for pkg in pkgs}
+reqs = map(Requirement, Distribution.from_name('dwave-ocean-sdk').requires)
+pkgs = [Distribution.from_name(req.name) for req in reqs]
+versions = {pkg.name: pkg.version for pkg in pkgs}
 
 def linkcode_resolve(domain, info):
     """

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,6 @@ matplotlib
 
 # Needed for minorminer C docs
 breathe
+
+# needed in docs.conf to parse package versions
+packaging


### PR DESCRIPTION
`pkg_resources` is not available in python 3.12 by default, as setuptools are not installed by default anymore. Furthermore, its usage has been deprecated in 3.12, to be replaced with `importlib.metadata` and `packaging` functionality.