### PR TITLE
CI: update Python versions to latest patch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ workflows:
       - test-linux:
           matrix:
             parameters:
-              python-version: &python-versions ["3.8.9", "3.9.4", "3.10.0", "3.11.0", "3.12.0"]
+              python-version: &python-versions ["3.8.19", "3.9.19", "3.10.14", "3.11.9", "3.12.3"]
       - test-macos:
           matrix:
             parameters:


### PR DESCRIPTION
Driven by inability to install 3.8.9 on M1.

This is an interim fix, until we update the CI/orb-ocean to dynamically select the latest version.