### PR TITLE
Fix double period on copyright

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ url = https://github.com/dwavesystems/dwave-ocean-sdk
 version = attr: dwaveoceansdk.__version__
 
 # keep description, author and author email up to date with dwaveoceansdk.package_info
-author = D-Wave Systems Inc.
+author = D-Wave
 author_email = tools@dwavesys.com
 description = Software development kit for open source D-Wave tools
 


### PR DESCRIPTION
@fionahanington noticed that the copyright has a double period:
![image](https://github.com/user-attachments/assets/eb1cc7eb-86b1-44b0-b643-1f50178fb51d)

Note that sphinx adds the copyright prefix and a period suffix to the author