### PR TITLE
Add pyqubo 1.5.0 to support Python 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
     dwavebinarycsp==0.3.0
     minorminer==0.2.15
     penaltymodel==1.1.0
+    pyqubo==1.5.0
 packages = dwaveoceansdk
 python_requires = >=3.8
 


### PR DESCRIPTION
Since PyQUBO now supports Python 3.12 and 3.13, we would appreciate it if you could add it back to the D-Wave Ocean SDK. Thank you for your consideration. 

Here is the latest release of PyQUBO:
https://pypi.org/project/pyqubo/