### PR TITLE
Fix footnote on fast-anneal resolution

### DIFF
--- a/docs/quantum_research/solver_parameters.rst
+++ b/docs/quantum_research/solver_parameters.rst
@@ -85,7 +85,7 @@ element in the pair is time :math:`t` and the second is anneal fraction
 :math:`s` in the range [0,1]. The resulting schedule is the piecewise-linear
 curve that connects the provided points.
 
-.. include:: ../shared/parameters.rst
+.. include:: ../shared/anneal.rst
     :start-after: start_time_granularity
     :end-before: end_time_granularity
 

--- a/docs/quantum_research/solver_properties_all.rst
+++ b/docs/quantum_research/solver_properties_all.rst
@@ -262,11 +262,9 @@ quench possible for this solver.
 Default annealing time is specified by the
 :ref:`property_qpu_default_annealing_time` property.
 
-..  [#]
-    The :ref:`fast-anneal protocol <qpu_annealprotocol_fast>` supports a time
-    granularity of about 0.05% of the anneal time. For annealing times of about
-    10 ns, the granularity is about 5 ps; for anneals of about 20 :math:`\mu s`,
-    it is reduced to around 10 ns.
+.. include:: ../shared/anneal.rst
+    :start-after: start_time_granularity_footnote
+    :end-before: end_time_granularity
 
 Example
 -------

--- a/docs/shared/anneal.rst
+++ b/docs/shared/anneal.rst
@@ -5,15 +5,15 @@ Time is specified in microseconds. For
 :ref:`standard anneals <qpu_annealprotocol_standard>`, input times are rounded
 to two decimal places (a granularity of 0.01 :math:`\mu s`); for the
 :ref:`fast-anneal protocol <qpu_annealprotocol_fast>`, you can specify times to
-a maximum resolution of 5%.\ [#]_
+a maximum resolution of 0.05%.\ [#]_
+
+.. start_time_granularity_footnote
 
 ..  [#]
-    For the fast-anneal protocol, if you are interested in annealing times of
-    about 2 ns (``[[0.0, 0.0], [0.002, 1.0]]``), for example, specify no more
-    than six decimal places for the time (a granularity of 1 ps), while for
-    anneals of about 20 ns, specify no more than five decimal places (a
-    granularity of 10 ps). Specifying additional decimal places is not
-    meaningful.
+    The :ref:`fast-anneal protocol <qpu_annealprotocol_fast>` supports a time
+    granularity of about 0.05% of the anneal time. For annealing times of about
+    10 ns, the granularity is about 5 ps; for anneals of about 20 :math:`\mu s`,
+    it is reduced to around 10 ns.
 
 .. end_time_granularity
 

--- a/docs/shared/parameters.rst
+++ b/docs/shared/parameters.rst
@@ -109,22 +109,3 @@ given problem. Can be a float or integer.
 Default value is problem dependent.
 
 .. end_parameter_time_limit
-
-
-.. start_time_granularity
-
-Time is specified in microseconds. For
-:ref:`standard anneals <qpu_annealprotocol_standard>`, input times are rounded
-to two decimal places (a granularity of 0.01 :math:`\mu s`); for the
-:ref:`fast-anneal protocol <qpu_annealprotocol_fast>`, you can specify times to
-a maximum resolution of 5%.\ [#]_
-
-..  [#]
-    For the fast-anneal protocol, if you are interested in annealing times of
-    about 2 ns (``[[0.0, 0.0], [0.002, 1.0]]``), for example, specify no more
-    than six decimal places for the time (a granularity of 1 ps), while for
-    anneals of about 20 ns, specify no more than five decimal places (a
-    granularity of 10 ps). Specifying additional decimal places is not
-    meaningful.
-
-.. end_time_granularity


### PR DESCRIPTION
A previous PR (for DOC-742) updated the footnote [here](https://docs.dwavequantum.com/en/latest/quantum_research/solver_properties_all.html#fast-anneal-time-range) but missed [this one](https://docs.dwavequantum.com/en/latest/quantum_research/solver_parameters.html#anneal-schedule). Also, "specify times to a maximum resolution of 5%" in the second link is a typo.
Additionally, the `start_time_granularity` content is duplicated while the two footnotes are not single sourced.
I'll add [Emile ](https://github.com/ehoskinson) as a reviewer once he's set up.