### PR TITLE
Fix expired links in the Per-QPU Specs page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 
 .. index-start-marker
 
-`Ocean <https://docs.ocean.dwavesys.com/en/stable>`_ is
+`Ocean SDK <https://docs.dwavequantum.com/en/latest/ocean/index.html>`_ is
 `D-Wave's <https://www.dwavesys.com>`_ suite of tools for solving hard problems
 with quantum computers.
 
@@ -32,7 +32,7 @@ Installation from `PyPI <https://pypi.org/project/dwave-ocean-sdk/>`_:
     pip install dwave-ocean-sdk
 
 For more information, see the Ocean documentation's
-`installation <https://docs.ocean.dwavesys.com/en/stable/overview/install.html>`_
+`installation <https://docs.dwavequantum.com/en/latest/ocean/install.html>`_
 page.
 
 .. installation-end-marker
@@ -45,24 +45,24 @@ Sign up for the Leap quantum cloud service here:
 
 Start learning with the following D-Wave resources:
 
-* `System Documentation <https://docs.dwavesys.com/docs/latest/index.html>`_ to
-  learn about quantum computers and how to use them.
+*   `D-Wave Documentation <https://docs.dwavequantum.com/en/latest/index.html>`_
+    to learn about quantum computers and how to use them.
 
-* `Getting Started with Ocean <https://docs.ocean.dwavesys.com/en/stable/getting_started.html>`_
-  to install and start coding with Ocean software.
+*   `Get Started with Ocean Software <https://docs.dwavequantum.com/en/latest/ocean/index_get_started.html>`_
+    to install and start coding with Ocean software.
 
-* `dwave-examples <https://github.com/dwave-examples>`_ for code examples
-  and Jupyter Notebooks.
+*   `dwave-examples <https://github.com/dwave-examples>`_ for code examples
+    and Jupyter Notebooks.
 
-* `Resource Library <https://www.dwavesys.com/learn/resource-library>`_ on
-  D-Wave website for whitepapers and additional resources.
+*   `Resource Library <https://www.dwavesys.com/learn/resource-library>`_ on
+    D-Wave website for whitepapers and additional resources.
 
 Example Quantum Program
 -----------------------
 
 The following lines of code solve and visualize a
-`random <https://docs.ocean.dwavesys.com/en/stable/docs_dimod/reference/generators.html>`_
-`problem <https://docs.ocean.dwavesys.com/en/stable/concepts/bqm.html>`_
+`random <https://docs.dwavequantum.com/en/latest/ocean/api_ref_dimod/generators.html>`_
+`problem <https://docs.dwavequantum.com/en/latest/concepts/models.html#binary-quadratic-models>`_
 on a quantum computer.
 
 .. code-block:: python
@@ -77,7 +77,7 @@ on a quantum computer.
   dwave.inspector.show(sampleset)
 
 The left side of the
-`visualized <https://docs.ocean.dwavesys.com/en/stable/docs_inspector/intro.html>`_
+`visualized <https://docs.dwavequantum.com/en/latest/quantum_research/embedding_guidance.html>`_
 solution represents the problem's variables as circles, with white dots for
 variables assigned values of -1 and blue dots for values of +1; the colors of the
 connecting lines represent values of the quadratic coefficients for each pair of
@@ -87,7 +87,7 @@ quantum processing unit.
 .. image:: docs/_static/inspector_bqm_ran_r_20.png
 
 You can find introductory examples in the
-`Ocean documentation <https://docs.ocean.dwavesys.com/en/stable/getting_started.html>`_
+`D-Wave documentation <https://docs.dwavequantum.com/en/latest/quantum_research/index_examples_beginner.html>`_
 and `dwave-examples <https://github.com/dwave-examples>`_ GitHub repository, and
 many customer prototype applications on the
 `D-Wave website <https://www.dwavesys.com/learn/featured-applications/>`_.
@@ -110,7 +110,8 @@ Contributing
 
 Your contributions are welcome!
 
-Ocean's `contributing guide <https://docs.ocean.dwavesys.com/en/stable/contributing.html>`_
+Ocean's
+`contributing guide <https://docs.dwavequantum.com/en/latest/ocean/contribute.html>`_
 has guidelines for contributing to Ocean packages.
 
 License

--- a/README.rst
+++ b/README.rst
@@ -67,14 +67,14 @@ on a quantum computer.
 
 .. code-block:: python
 
-  import dimod
-  import dwave.inspector
-  import dwave.system
+    import dimod
+    import dwave.inspector
+    import dwave.system
 
-  bqm = dimod.generators.ran_r(1, 20)
-  sampler = dwave.system.EmbeddingComposite(dwave.system.DWaveSampler())
-  sampleset = sampler.sample(bqm, num_reads=100)
-  dwave.inspector.show(sampleset)
+    bqm = dimod.generators.ran_r(1, 20)
+    sampler = dwave.system.EmbeddingComposite(dwave.system.DWaveSampler())
+    sampleset = sampler.sample(bqm, num_reads=100)
+    dwave.inspector.show(sampleset)
 
 The left side of the
 `visualized <https://docs.dwavequantum.com/en/latest/quantum_research/embedding_guidance.html>`_
@@ -97,13 +97,13 @@ Support
 
 Find support here:
 
-* `Leap user community <https://support.dwavesys.com/hc/en-us/community/topics>`_
-  to converse with a large community of D-Wave users.
-* `Leap help center <https://support.dwavesys.com/hc/en-us>`_
-  to search the Leap knowledge base.
-* `SDK GitHub repo <https://github.com/dwavesystems/dwave-ocean-sdk/issues>`_ to
-  open issues or request features on the Ocean SDK or on any one of its
-  `packages <https://github.com/dwavesystems>`_.
+*   `Leap user community <https://support.dwavesys.com/hc/en-us/community/topics>`_
+    to converse with a large community of D-Wave users.
+*   `Leap help center <https://support.dwavesys.com/hc/en-us>`_
+    to search the Leap knowledge base.
+*   `SDK GitHub repo <https://github.com/dwavesystems/dwave-ocean-sdk/issues>`_
+    to open issues or request features on the Ocean SDK or on any one of its
+    `packages <https://github.com/dwavesystems>`_.
 
 Contributing
 ============

--- a/docs/quantum_research/solver_properties_specific.rst
+++ b/docs/quantum_research/solver_properties_specific.rst
@@ -17,12 +17,10 @@ This information includes:
         In addition to the physical properties listed herein, each QPU has
         a number of other properties defined in software that are accessible via
         the Solver API. For a global list of the solver properties for a QPU,
-        and for a list of the permitted user parameters for each type of solver,
-        see
-        `Solver Properties and Parameters <https://docs.dwavesys.com/docs/latest/doc_solver_ref.html>`_.
-        To retrieve the solver properties for a particular QPU, see the
-        `Ocean software documentation <https://docs.ocean.dwavesys.com/en/stable/docs_cloud/reference/generated/dwave.cloud.client.Client.get_solver.html#dwave.cloud.client.Client.get_solver>`_
-        for the syntax and examples.
+        see the :ref:`qpu_solver_properties_all` page and for a list of the
+        permitted user parameters for each type of solver, see the
+        :ref:`qpu_solver_parameters` page. To retrieve the solver properties for
+        a particular QPU, see the examples on those pages.
 
 *   Spreadsheet for a QPU's annealing-schedule functions and normalized
     annealing-waveform values---These values are required for computing
@@ -100,7 +98,7 @@ This table lists the physical properties of the calibrated QPU.
     *   - :math:`I_c`: Qubit critical current
         - :math:`4.57\ \text{µA}`
 
-    *   - `Average single-qubit temperature <https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.temperatures.fast_effective_temperature.html#dwave.system.temperatures.fast_effective_temperature>`_
+    *   - :ref:`Average single-qubit temperature <system_utilities>`
         - :math:`0.117`
 
     *   - :ref:`Ferromagnetic-problem freezeout <qpu_qa_freezeout>`
@@ -204,7 +202,7 @@ This table lists the physical properties of the calibrated QPU.
     *   - :math:`I_c`: Qubit critical current
         - :math:`1.94\ \text{µA}`
 
-    *   - `Average single-qubit temperature <https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.temperatures.fast_effective_temperature.html#dwave.system.temperatures.fast_effective_temperature>`_
+    *   - :ref:`Average single-qubit temperature <system_utilities>`
         - :math:`0.228`
 
     *   - :ref:`Ferromagnetic-problem freezeout <qpu_qa_freezeout>`
@@ -336,7 +334,7 @@ This table lists the physical properties of the calibrated QPU.
     *   - :math:`I_c`: Qubit critical current
         - :math:`1.99\ \text{µA}`
 
-    *   - `Average single-qubit temperature <https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.temperatures.fast_effective_temperature.html#dwave.system.temperatures.fast_effective_temperature>`_
+    *   - :ref:`Average single-qubit temperature <system_utilities>`
         - :math:`0.221`
 
     *   - :ref:`Ferromagnetic-problem freezeout <qpu_qa_freezeout>`
@@ -468,7 +466,7 @@ This table lists the physical properties of the calibrated QPU.
     *   - :math:`I_c`: Qubit critical current
         - :math:`2.10\ \text{µA}`
 
-    *   - `Average single-qubit temperature <https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.temperatures.fast_effective_temperature.html#dwave.system.temperatures.fast_effective_temperature>`_
+    *   - :ref:`Average single-qubit temperature <system_utilities>`
         - :math:`0.193`
 
     *   - :ref:`Ferromagnetic-problem freezeout <qpu_qa_freezeout>`
@@ -600,7 +598,7 @@ This table lists the physical properties of the calibrated QPU.
     *   - :math:`I_c`: Qubit critical current
         - :math:`2.1\ \text{µA}`
 
-    *   - `Average single-qubit temperature <https://docs.ocean.dwavesys.com/en/stable/docs_system/reference/generated/dwave.system.temperatures.fast_effective_temperature.html#dwave.system.temperatures.fast_effective_temperature>`_
+    *   - :ref:`Average single-qubit temperature <system_utilities>`
         - :math:`0.198`
 
     *   - :ref:`Ferromagnetic-problem freezeout <qpu_qa_freezeout>`


### PR DESCRIPTION
@arcondello caught a couple of leftover links to the old doc sites and I saw a few more in the README. 