### PR TITLE
Add xrefs to energy-scale utility functions

### DIFF
--- a/docs/quantum_research/annealing.rst
+++ b/docs/quantum_research/annealing.rst
@@ -527,6 +527,10 @@ typical :math:`B_i(s)` versus :math:`s` for the same set of :math:`\delta c_i`.
     :math:`\delta c_i = -0.05` (delays the annealing process for the qubit).
     Data shown are representative of |dwave_2kq| systems.
 
+:ref:`Ocean software <index_ocean_sdk>` provides a utility function,
+:func:`~dwave.system.utilities.anneal_schedule_with_offset`, you can use to
+calculate the energy scales for a given anneal offset.
+
 The change of :math:`B(s)\rightarrow B_i(s)` has consequences for the target
 Ising spin Hamiltonian parameters :math:`h_i` and :math:`J_{i,j}`. The anneal
 offset for the :math:`i{\rm th}` qubit deflects
@@ -712,6 +716,9 @@ causes the system to produce linear changes in :math:`s` between :math:`s_i` and
 The table below gives three valid examples of anneal schedule points, producing
 the varying patterns of :math:`B(t)` that appear in
 :numref:`Figure %s <annealing_trajectories>`.
+:ref:`Ocean software <index_ocean_sdk>` provides a utility function,
+:func:`~dwave.system.utilities.energy_scales_custom_schedule`, you can use to
+calculate the energy scales generated for your custom anneal schedule.
 
 
 .. list-table:: Anneal Schedule Tuples: Examples

--- a/docs/quantum_research/solver_parameters.rst
+++ b/docs/quantum_research/solver_parameters.rst
@@ -34,6 +34,10 @@ standard trajectory). Before using this parameter, query the solver properties
 to see whether the :ref:`property_qpu_anneal_offset_ranges` property exists and,
 if so, to obtain the permitted offset values per qubit. Default is no offsets.
 
+:ref:`Ocean software <index_ocean_sdk>` provides a utility function,
+:func:`~dwave.system.utilities.anneal_schedule_with_offset`, you can use to
+calculate the energy scales for a given anneal offset.
+
 Relevant Properties
 -------------------
 
@@ -95,6 +99,9 @@ curve that connects the provided points.
 
 Default anneal schedules are described in the
 :ref:`QPU-specific anneal schedules <qpu_solver_properties_specific>` section.
+:ref:`Ocean software <index_ocean_sdk>` provides a utility function,
+:func:`~dwave.system.utilities.energy_scales_custom_schedule`, you can use to
+calculate the energy scales generated for your custom anneal schedule.
 
 Relevant Properties
 -------------------


### PR DESCRIPTION
Merge only for SDK version of [dwave-system](https://github.com/dwavesystems/dwave-system) > 1.13.

Closes the loop on previous `dwave-system` PRs for [DOC-436](https://github.com/dwavesystems/dwave-system/pull/568) & [DOC-759](https://github.com/dwavesystems/dwave-system/pull/570), which provided users an easy way of plotting energy scales for a given anneal offset or custom anneal schedule. 

The xrefs won't work currently but have been tested locally with main branch of `dwave-system`:

![image](https://github.com/user-attachments/assets/10066c4c-545c-453e-ab13-b113e7da166b)

