### PR TITLE
Update post-read delay for Advantage2

### DIFF
--- a/docs/quantum_research/errors.rst
+++ b/docs/quantum_research/errors.rst
@@ -922,6 +922,13 @@ submit the problem at least twice.
 Spin-Bath Polarization Effect
 -----------------------------
 
+.. note::
+    This source of noise is vastly reduced on |adv2| quantum computers;
+    consequently, usage of the
+    :ref:`parameter_qpu_reduce_intersample_correlation` and
+    :ref:`parameter_qpu_readout_thermalization` parameters should be considered
+    for |dwave_5kq| systems only.
+
 One of the main sources of environmental noise affecting the qubit is magnetic
 fluctuations from an ensemble of spins local to the qubit wiring. This produces
 low-frequency flux noise that can cause the misspecification errors referred to
@@ -938,28 +945,22 @@ distribution. The partially polarized environment can also produce
 sample-to-sample correlations, biasing the QPU towards previously achieved spin
 configurations.
 
-To reduce these sample-to-sample correlations, enable the
-:ref:`parameter_qpu_reduce_intersample_correlation` solver parameter. This
-setting adds optimal delay times before each anneal, giving the spin bath time
-to depolarize and thereby lose the effects from the previous read. It adds a
-delay that varies (approximately) between :math:`200` microseconds and
-:math:`10` milliseconds, increasing linearly with increasing length of the
-schedule:
+You can reduce these sample-to-sample correlations, with the
+:ref:`parameter_qpu_reduce_intersample_correlation` and/or
+:ref:`parameter_qpu_readout_thermalization` solver parameters. These parameters
+add a delay after each anneal,\ [#]_ giving the spin bath time to depolarize and
+thereby lose the effects from the previous read.
 
-.. math::
-    :nowrap:
-
-    \begin{equation}
-        delay = 500 + \frac{\rm{T} (10000 - 500)}{2000}
-    \end{equation}
-
-where T is the total time of the anneal schedule.
+.. [#]
+    An exception is for :ref:`reverse annealing <qpu_qa_anneal_sched_reverse>`
+    as described by the :ref:`parameter_qpu_reinitialize_state` parameter.
 
 .. important::
-    Enabling this parameter drastically increases problem run times. To avoid
-    exceeding the maximum problem run time configured for your system, limit the
-    number of reads  when using this feature. For more information, see the
-    :ref:`qpu_operation_timing` section.
+    Enabling the :ref:`parameter_qpu_reduce_intersample_correlation` parameter
+    on an |dwave_5kq| quantum computer drastically increases problem run times.
+    To avoid exceeding the maximum problem run time configured for your system,
+    limit the number of reads  when using this feature. For more information,
+    see the :ref:`qpu_operation_timing` section.
 
 The anneal schedule feature discussed in the :ref:`qpu_annealing` chapter allows
 you to insert pauses at intermediate values of :math:`s`. Be aware that pausing

--- a/docs/quantum_research/solver_parameters.rst
+++ b/docs/quantum_research/solver_parameters.rst
@@ -13,6 +13,7 @@ these solvers, such as the ranges within which parameter values must be set.
 
 .. |meet_run_duration| replace:: :ref:`parameter_qpu_anneal_schedule` or
     :ref:`parameter_qpu_annealing_time`,
+    :ref:`parameter_qpu_reduce_intersample_correlation` and/or
     :ref:`parameter_qpu_readout_thermalization`, :ref:`parameter_qpu_num_reads`
     (samples), and :ref:`parameter_qpu_programming_thermalization` values taken
     together must meet the limitations specified in
@@ -1107,6 +1108,10 @@ floating-point numbers.
 Default value for a solver is given in the
 :ref:`property_qpu_default_readout_thermalization` property.
 
+.. include:: ../shared/parameters.rst
+    :start-after: start_parameter_delay_after_read
+    :end-before: end_parameter_delay_after_read
+
 Relevant Properties
 -------------------
 
@@ -1117,6 +1122,8 @@ Interacts with Parameters
 -------------------------
 
 *   |meet_run_duration|
+*   Delays from :ref:`parameter_qpu_readout_thermalization` and
+    :ref:`parameter_qpu_reduce_intersample_correlation` aggregate.
 
 Example
 -------
@@ -1138,7 +1145,7 @@ reduce_intersample_correlation
 ==============================
 
 Reduces sample-to-sample correlations caused by the spin-bath polarization
-effect\ [#]_ by adding a delay between reads.
+effect\ [#]_ by adding a delay after each read.
 
 .. [#]
 
@@ -1150,13 +1157,39 @@ Boolean flag indicating whether the system adds a delay.
 *   ``reduce_intersample_correlation=True``: Adds delay.
 *   ``reduce_intersample_correlation=False`` (default): Does not add delay.
 
+.. include:: ../shared/parameters.rst
+    :start-after: start_parameter_delay_after_read
+    :end-before: end_parameter_delay_after_read
+
 .. important::
     Enabling this parameter drastically increases problem run times. To avoid
     exceeding the maximum problem run time configured for your system, limit the
     number of reads when using this feature. For more information on timing,
     see the :ref:`qpu_operation_timing` section.
 
-Default is to not add delay between reads.
+Activating this parameter adds a delay that increases linearly with the
+length of the anneal schedule. The value of the delay varies in the range of the
+:ref:`property_qpu_problem_timing_data` property's ``decorrelation_time_range``
+field. For example, on the
+``Advantage_system4.1`` solver, with an :ref:`property_qpu_annealing_time_range`
+of ``[o.5, 2000]`` microseconds and ``decorrelation_time_range`` of
+``[500, 10000]`` microseconds, the delay is given by:
+
+.. math::
+    :nowrap:
+
+    \begin{equation}
+        delay = 500 + \frac{\rm{T} (10000 - 500)}{2000}
+    \end{equation}
+
+where T is the total time of the anneal schedule.
+
+Interacts with Parameters
+-------------------------
+
+*   |meet_run_duration|
+*   Delays from :ref:`parameter_qpu_readout_thermalization` and
+    :ref:`parameter_qpu_reduce_intersample_correlation` aggregate.
 
 Example
 -------

--- a/docs/shared/parameters.rst
+++ b/docs/shared/parameters.rst
@@ -109,3 +109,15 @@ given problem. Can be a float or integer.
 Default value is problem dependent.
 
 .. end_parameter_time_limit
+
+
+.. start_parameter_delay_after_read
+
+.. note::
+    Usage of the
+    :ref:`parameter_qpu_reduce_intersample_correlation` and
+    :ref:`parameter_qpu_readout_thermalization` parameters is not recommended
+    for |adv2| systems; see the :ref:`qpu_errors_spinbath_polarization` section
+    for details.
+
+.. end_parameter_delay_after_read


### PR DESCRIPTION
Let me know if you think we should use stronger language. 
For HTML comparison, here is the existing content:

- [Spin-Bath Polarization Effect](https://docs.dwavequantum.com/en/latest/quantum_research/errors.html#spin-bath-polarization-effect)
- [readout_thermalization](https://docs.dwavequantum.com/en/latest/quantum_research/solver_parameters.html#readout-thermalization)
- [reduce_intersample_correlation](https://docs.dwavequantum.com/en/latest/quantum_research/solver_parameters.html#reduce-intersample-correlation)

and here are the changes:

![image](https://github.com/user-attachments/assets/1e01d30c-8915-4332-814e-2da7ed04eb6c)
![image](https://github.com/user-attachments/assets/cca90517-e8a5-42a4-bf22-0967cd88174f)
![image](https://github.com/user-attachments/assets/ecdb2e8e-84e8-443b-9241-62e8adfb08f0)
![image](https://github.com/user-attachments/assets/eb3920a6-e5f4-4b8d-9433-f904bbb49048)
![image](https://github.com/user-attachments/assets/af90b3c5-5c68-4b8c-b7e1-0b61b9c35998)
![image](https://github.com/user-attachments/assets/a4b007e1-8bc9-44b2-b78f-1d7400ce2547)
