### PR TITLE
Fix invalid doctest directive

### DIFF
--- a/docs/industrial_optimization/solver_dqm_parameters.rst
+++ b/docs/industrial_optimization/solver_dqm_parameters.rst
@@ -44,8 +44,10 @@ rock-paper-scissors---to Ocean software's
 >>> win = {"rock": "scissors", "paper": "rock", "scissors": "paper"}
 ...
 >>> dqm = dimod.DiscreteQuadraticModel()
->>> dqm.add_variable(3, label='my_hand')    # doctest: +IGNORE_RESULT
->>> dqm.add_variable(3, label='their_hand') # doctest: +IGNORE_RESULT
+>>> dqm.add_variable(3, label='my_hand')
+'my_hand'
+>>> dqm.add_variable(3, label='their_hand')
+'their_hand'
 >>> for my_idx, my_case in enumerate(cases):
 ...    for their_idx, their_case in enumerate(cases):
 ...       if win[my_case] == their_case:


### PR DESCRIPTION
To close [this PR comment](https://github.com/dwavesystems/dwave-ocean-sdk/pull/349#pullrequestreview-2864688741).
From what I [see here](https://docs.python.org/3/library/doctest.html#option-flags), doctest doesn't support a ``IGNORE_RESULT`` directive, and sphinx enables three directives [by default](https://github.com/sphinx-doc/sphinx/blob/1a69059295e297f987b58918bd40a6c93771f1d8/sphinx/ext/doctest.py#L653) but does not add such a thing itself through the `doctest.register_optionflag()`. We could consider adding this ourselves but it is only used here so until such a time, I think we can just show the output for this example. 