### PR TITLE
Ensure CQM example returns feasible results & update statement on Zephyr

### DIFF
--- a/docs/industrial_optimization/workflow.rst
+++ b/docs/industrial_optimization/workflow.rst
@@ -123,8 +123,7 @@ solver provided by the Leap quantum cloud service:
 ...     sampleset = sampler.sample_cqm(cqm)
 ...     feasible_results = sampleset.filter(lambda d: d.is_feasible)
 ...     print(feasible_results.first)
-Sample(sample={'i': 2.0, 'j': 2.0}, energy=-4.0, num_occurrences=1,
-...            is_feasible=True, is_satisfied=array([ True]))
+Sample(sample={'i': 2.0, 'j': 2.0}, energy=-4.0, num_occurrences=1, is_satisfied=array([ True]), is_feasible=True)
 
 The best (lowest-energy) solution found has :math:`i=j=2` as expected, a
 solution that is feasible because all the constraints (one in this example)

--- a/docs/industrial_optimization/workflow.rst
+++ b/docs/industrial_optimization/workflow.rst
@@ -119,9 +119,10 @@ solver provided by the Leap quantum cloud service:
 
 >>> from dwave.system import LeapHybridCQMSampler
 ...
->>> sampler = LeapHybridCQMSampler()                # doctest: +SKIP
->>> sampleset = sampler.sample_cqm(cqm)             # doctest: +SKIP
->>> print(sampleset.first)                          # doctest: +SKIP
+>>> with LeapHybridCQMSampler() as sampler:         # doctest: +SKIP
+...     sampleset = sampler.sample_cqm(cqm)
+...     feasible_results = sampleset.filter(lambda d: d.is_feasible)
+...     print(feasible_results.first)
 Sample(sample={'i': 2.0, 'j': 2.0}, energy=-4.0, num_occurrences=1,
 ...            is_feasible=True, is_satisfied=array([ True]))
 

--- a/docs/quantum_research/topologies.rst
+++ b/docs/quantum_research/topologies.rst
@@ -374,11 +374,11 @@ qubits that are divided between adjacent such unit cells, as shown in
 Zephyr Graph
 ============
 
-|dwave_short| is currently developing its next-generation QPU with the
-Zephyr\ |tm| topology: qubits are “oriented” vertically or horizontally, as in
-the Chimera and Pegasus topologies, and are shifted and connected with three
-coupler types as in the Pegasus topology, but this new graph achieves higher
-nominal length (16) and degree (20). A qubit in the Zephyr topology has sixteen
+|adv2_tm| QPUs feature the Zephyr\ |tm| topology: qubits are “oriented”
+vertically or horizontally, as in the Chimera and Pegasus topologies, and are
+shifted and connected with three coupler types as in the Pegasus topology, but
+this new graph achieves higher nominal length (16) and degree (20). A qubit in
+the Zephyr topology has sixteen
 :ref:`internal couplers <topologies_couplers_internal>` connecting it to
 orthogonal qubits and two
 :ref:`external couplers <topologies_couplers_external>` and two


### PR DESCRIPTION
Two minor fixes (DOC-890 & DOC-998): CQM example did not always return feasible result as the first sample and Zephyr-based QPU is now a product. 
Related: [PR-596](https://github.com/dwavesystems/dwave-system/pull/596)