### PR TITLE
Remove previously deprecated SAPI string id (replaced by identity dictionary); add history of working-graph changes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -270,6 +270,7 @@ intersphinx_mapping = {
     'networkx': ('https://networkx.org/documentation/stable/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/stable/', None),
     'requests': ('https://requests.readthedocs.io/en/stable/', None),
+    'ocean_rns': ('https://docs.dwavequantum.com/projects/leap_sapi/en/latest/', None),
     }
 
 

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -51,31 +51,34 @@ The following table describes some of the most frequently encountered codes.
 
 .. table:: HTTP Response Codes
 
-    ========================== ================================================
-    Code                       Explanation
-    ========================== ================================================
-    200  OK	                   No error.
-    201  CREATED               Creation of a resource was successful.
-    202  ACCEPTED              Request such as problem cancellation was
-                               received.
-    304  NOT MODIFIED          The requested resource has not changed since
-                               the time specified in the request's
-                               ``If-Modified-Since`` header.
-    400  BAD REQUEST           Invalid request URI or header, or unsupported
-                               nonstandard parameter.
-    401  UNAUTHORIZED          Authorization required. This error can also mean
-                               that incorrect user credentials were sent with
-                               the request.
-    403  FORBIDDEN             Unsupported standard parameter, or
-                               authentication or authorization failed.
-    404  NOT FOUND             Resource (such as a problem) not found.
-    409  CONFLICT              Conflict such as a request for problem
-                               cancellation.
-                               for a problem that has already terminated.
-    429  TOO MANY REQUESTS     API request rate exceeds the permissible limit.
-    500  INTERNAL SERVER ERROR Internal error. This is the default code that is
-                               used for all unrecognized server errors.
-    ========================== ================================================
+    =========================== ================================================
+    Code                        Explanation
+    =========================== ================================================
+    200  OK	                    No error.
+    201  CREATED                Creation of a resource was successful.
+    202  ACCEPTED               Request such as problem cancellation was
+                                received.
+    304  NOT MODIFIED           The requested resource has not changed since
+                                the time specified in the request's
+                                ``If-Modified-Since`` header.
+    400  BAD REQUEST            Invalid request URI or header, or unsupported
+                                nonstandard parameter.
+    401  UNAUTHORIZED           Authorization required. This error can also mean
+                                that incorrect user credentials were sent with
+                                the request.
+    403  FORBIDDEN              Unsupported standard parameter, or
+                                authentication or authorization failed.
+    404  NOT FOUND              Resource (such as a problem) not found.
+    409  CONFLICT               Conflict, such as a request for problem
+                                cancellation for a problem that has already
+                                terminated.
+    415  UNSUPPORTED MEDIA TYPE Unsupported media type, such as an unsupported
+                                SAPI resource-representation version in the
+                                ``Accept`` header.
+    429  TOO MANY REQUESTS      API request rate exceeds the permissible limit.
+    500  INTERNAL SERVER ERROR  Internal error. This is the default code that is
+                                used for all unrecognized server errors.
+    =========================== ================================================
 
 .. _sapi_rest_lifecycle:
 
@@ -731,6 +734,9 @@ Submit Problems
 To submit problems to a solver in the Leap service, send an HTTP POST request to
 the ``problems`` endpoint.
 
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problems+json; version=3``.
+
 The POST request body should contain the JSON-encoded fields described below.
 When possible, if you have more than one problem, submit them in a single
 query.\ [#]_
@@ -753,14 +759,10 @@ query.\ [#]_
         params          Solver-specific
                         :ref:`hybrid parameters <opt_index_properties_parameters>`
                         or :ref:`QPU parameters <qpu_solver_parameters>`.
-        solver          Unique identifier (name) of the solver to be used. For
-                        resource representation ``version=2.1`` and earlier, use
-                        the name of the solver (e.g., ``"solver": "Advantage_system4.1"``).
-                        The ``version=2.1`` resource representation is
-                        deprecated; instead, use the ``version=3`` JSON
-                        structure. For resource representation ``version=3``,
-                        the solver identifier is represented by the following
-                        JSON structure::
+        solver          Unique identifier (name) of the solver to be used.
+                        For resource representation ``version=3``, the solver
+                        identifier is represented by the following JSON
+                        structure::
 
                         {"name": solver_name, "version": {"graph_id": graph_id}}
 
@@ -909,19 +911,6 @@ sampler,see the :ref:`sapi_rest_full_examples` section.
     problems in a single query, the list is the comma-separated fields of each
     problem: ``[{"solver": ...},{"solver": ...},...{"solver": ...}]``.
 
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
-        field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
-
 .. dropdown:: 2xx responses
     :color: success
 
@@ -986,6 +975,12 @@ sampler,see the :ref:`sapi_rest_full_examples` section.
     {'error_code': 400,
      'error_msg': 'Solver does not exist or apitoken does not have access'}
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 .. _sapi_rest_cancel_many_problems:
 
 Cancel Multiple Problems
@@ -993,6 +988,9 @@ Cancel Multiple Problems
 
 To cancel pending problems (problems with status ``PENDING``), send an HTTP
 DELETE request to the ``problems`` endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problems+json; version=3``.
 
 The request body should be a JSON-encoded list of problem IDs; if the request
 body is empty, the request has no effect.
@@ -1020,20 +1018,6 @@ single query.
             $ accept="Accept: application/vnd.dwave.sapi.problems+json; version=3"
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ curl -H "$auth" -H "$accept" $SAPI_HOME/problems -X DELETE -d $id_list
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
-        field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
-
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1088,6 +1072,12 @@ single query.
     [{'error_code': 409, 'error_msg': 'Problem has been finished.'},
      {'error_code': 409, 'error_msg': 'Problem has been finished.'}]
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 .. _sapi_rest_cancel_problem_by_id:
 
 Cancel a Problem by ID
@@ -1095,6 +1085,9 @@ Cancel a Problem by ID
 
 To cancel a previously submitted problem, make an HTTP DELETE request to the
 ``problems/<problem_id>`` endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problems+json; version=3``.
 
 The request should contain no body.
 
@@ -1118,19 +1111,6 @@ The request should contain no body.
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ accept="Accept: application/vnd.dwave.sapi.problem+json; version=3"
             $ curl -H "$auth" -H "$accept" $SAPI_HOME/problems/$problem_id -X DELETE
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problem+json; version=3``: The
-        ``solver`` field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1171,6 +1151,12 @@ The request should contain no body.
     {'error_code': 409,
      'error_msg': 'Problem has been finished.'}
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 .. _sapi_rest_list_problems:
 
 List Problems
@@ -1178,6 +1164,9 @@ List Problems
 
 To retrieve a list of problems, send an HTTP GET request to the ``problems``
 endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problems+json; version=3``.
 
 The request should contain no body.
 
@@ -1228,19 +1217,6 @@ with an ampersand ("&").
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ accept="Accept: application/vnd.dwave.sapi.problems+json; version=3"
             $ curl -H "$auth" -H "$accept" "$SAPI_HOME/problems/?$filter"
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
-        field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success
@@ -1293,6 +1269,12 @@ with an ampersand ("&").
     >>> r.text   # doctest: +SKIP
     'Problem does not exist or apitoken does not have access'
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 .. _sapi_rest_get_problem:
 
 Retrieve a Problem
@@ -1300,6 +1282,9 @@ Retrieve a Problem
 
 To retrieve a previously submitted problem, send an HTTP GET request to the
 ``problems/<problem_id>`` endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problem+json; version=3``.
 
 The request should contain no body.
 
@@ -1329,19 +1314,6 @@ not completed processing.
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ accept="Accept: application/vnd.dwave.sapi.problem+json; version=3"
             $ curl -H "$auth" -H "$accept" "$SAPI_HOME/problems/$problem_id?timeout=5"
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problem+json; version=3``: The ``solver``
-        field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1390,6 +1362,12 @@ not completed processing.
     {'error_code': 404,
      'error_msg': 'Problem does not exist or apitoken does not have access'}
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 .. _sapi_rest_get_problem_info:
 
 Retrieve Problem Information
@@ -1397,6 +1375,9 @@ Retrieve Problem Information
 
 To retrieve information about a problem, send an HTTP GET request to the
 ``problems/<problem_id>/info`` endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.problem-data+json; version=3``.
 
 The request should contain no body.
 
@@ -1419,19 +1400,6 @@ The request should contain no body.
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ accept="Accept: application/vnd.dwave.sapi.problem-data+json; version=3"
             $ curl -H "$auth" -H "$accept" $SAPI_HOME/problems/$problem_id/info
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation:
-
-    *   ``application/vnd.dwave.sapi.problem-data+json; version=3``: The
-        ``solver`` field is a dict.
-
-    For information, see :ref:`key_value_problems_request`.
-
-    No longer supported:
-
-    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1487,6 +1455,12 @@ The request should contain no body.
     >>> r.json()   # doctest: +SKIP
     {'error_code': 404,
      'error_msg': 'Problem does not exist or apitoken does not have access'}
+
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. _sapi_rest_get_problem_answer:
 
@@ -1661,6 +1635,9 @@ Retrieve Available Solvers
 To retrieve a list of available solvers from the Leap service, send an HTTP GET
 request to the ``solvers/remote`` endpoint.
 
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.solver-definition-list+json; version=3``.
+
 The request should contain no body.
 
 The request supports the use of the ``If-None-Match`` request header. If the
@@ -1698,20 +1675,6 @@ to get a subset of solver fields.
             $ accept="Accept: application/vnd.dwave.sapi.solver-definition-list+json; version=3"
             $ url="$SAPI_HOME/solvers/remote/"
             $ curl -H "$auth" -H "$accept" -G "$url" --data-urlencode "$filter"
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation in the response:
-
-    *   ``application/vnd.dwave.sapi.solver-definition-list+json; version=3``:
-        The solver ``identity`` field is a dict.
-
-    For information, see the "Solver Resource Fields" table in the
-    :ref:`available_solvers_2xx` tab.
-
-    No longer supported:
-
-    *   ``version=2``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success
@@ -1765,6 +1728,12 @@ to get a subset of solver fields.
 
     * ``304`` for unmodified resource
 
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2``: The ``solver`` field is a string.
+
 .. _sapi_rest_get_remote_solver_config:
 
 Retrieve Solver Fields
@@ -1772,6 +1741,9 @@ Retrieve Solver Fields
 
 To retrieve the fields of a solver, send an HTTP GET request to the
 ``solvers/remote/<solver_name>`` endpoint.
+
+The ``Accept`` header should be set to
+``application/vnd.dwave.sapi.solver-definition+json; version=3``.
 
 The request supports the ``If-None-Match`` request header. If the ``ETag``
 (entity tag) value in the request header matches the one on the server, a
@@ -1807,20 +1779,6 @@ to get a subset of solver fields.
             $ auth="X-Auth-Token: $SAPI_TOKEN"
             $ accept="Accept: application/vnd.dwave.sapi.solver-definition+json; version=3"
             $ curl -H "$auth" -H "$accept" $SAPI_HOME/solvers/remote/$solver_name
-
-.. dropdown:: Optional ``Accept`` header
-
-    SAPI supports the resource representation in the response:
-
-    *   ``application/vnd.dwave.sapi.solver-definition+json; version=3``:
-        The solver ``identity`` field is a dict.
-
-    For information, see the "Solver Resource Fields" table in the
-    :ref:`solver_fields_2xx` tab.
-
-    No longer supported:
-
-    *   ``version=2``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success
@@ -1858,6 +1816,12 @@ to get a subset of solver fields.
     |general error responses|
 
     *   ``304`` for unmodified resource
+
+.. dropdown:: Unsupported ``Accept`` header
+
+    No longer supported:
+
+    *   ``version=2``: The ``solver`` field is a string.
 
 .. _sapi_rest_full_examples:
 

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -911,16 +911,16 @@ sampler,see the :ref:`sapi_rest_full_examples` section.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports this resource representation:
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
         field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
 
-    .. dropdown:: Unsupported ``solver`` field type
+    No longer supported:
 
-        The ``solver`` field as a string is not supported.
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1023,15 +1023,17 @@ single query.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
         field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
+
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1119,15 +1121,16 @@ The request should contain no body.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problem+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problem+json; version=3``: The
         ``solver`` field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1228,15 +1231,16 @@ with an ampersand ("&").
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
         field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success
@@ -1328,15 +1332,16 @@ not completed processing.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problem+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problem+json; version=3``: The ``solver``
         field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1417,15 +1422,16 @@ The request should contain no body.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problem-data+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports the resource representation:
 
     *   ``application/vnd.dwave.sapi.problem-data+json; version=3``: The
         ``solver`` field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    No longer supported:
+
+    *   ``version=2.1``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx responses
     :color: success
@@ -1695,16 +1701,17 @@ to get a subset of solver fields.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations in the response:
-
-    *   ``application/vnd.dwave.sapi.solver-definition-list+json; version=2``
-        (default, deprecated): The solver ``id`` field is a string.
+    SAPI supports the resource representation in the response:
 
     *   ``application/vnd.dwave.sapi.solver-definition-list+json; version=3``:
         The solver ``identity`` field is a dict.
 
     For information, see the "Solver Resource Fields" table in the
     :ref:`available_solvers_2xx` tab.
+
+    No longer supported:
+
+    *   ``version=2``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success
@@ -1803,16 +1810,17 @@ to get a subset of solver fields.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations in the response:
-
-    *   ``application/vnd.dwave.sapi.solver-definition+json; version=2``
-        (default, deprecated): The solver ``id`` field is a string.
+    SAPI supports the resource representation in the response:
 
     *   ``application/vnd.dwave.sapi.solver-definition+json; version=3``:
         The solver ``identity`` field is a dict.
 
     For information, see the "Solver Resource Fields" table in the
     :ref:`solver_fields_2xx` tab.
+
+    No longer supported:
+
+    *   ``version=2``: The ``solver`` field is a string.
 
 .. dropdown:: 2xx response
     :color: success

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -759,7 +759,7 @@ query.\ [#]_
         params          Solver-specific
                         :ref:`hybrid parameters <opt_index_properties_parameters>`
                         or :ref:`QPU parameters <qpu_solver_parameters>`.
-        solver          Unique identifier (name) of the solver to be used.
+        solver          Unique identifier of the solver to be used.
                         For resource representation ``version=3``, the solver
                         identifier is represented by the following JSON
                         structure::
@@ -2235,6 +2235,7 @@ section.
 .. doctest:: rest_live
     :skipif: test_api_token_set == False or hss_spot_check == False
 
+    >>> session.headers['Accept'] = 'application/vnd.dwave.sapi.problem+json; version=3'
     >>> r9 = session.get(f"{SAPI_HOME}/problems/{problem_id}")
     >>> r9 = r9.json()
     >>> if r9['status'] == 'COMPLETED':       # doctest: +SKIP

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -911,15 +911,16 @@ sampler,see the :ref:`sapi_rest_full_examples` section.
 
 .. dropdown:: Optional ``Accept`` header
 
-    SAPI supports these resource representations:
-
-    *   ``application/vnd.dwave.sapi.problems+json; version=2.1`` (default,
-        deprecated): The ``solver`` field is a string.
+    SAPI supports this resource representation:
 
     *   ``application/vnd.dwave.sapi.problems+json; version=3``: The ``solver``
         field is a dict.
 
     For information, see :ref:`key_value_problems_request`.
+
+    .. dropdown:: Unsupported ``solver`` field type
+
+        The ``solver`` field as a string is not supported.
 
 .. dropdown:: 2xx responses
     :color: success

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -138,7 +138,7 @@ explained in the :ref:`sapi_rest_url_token_setup` subsection.
     >>> r = requests.get(f"{SAPI_HOME}/problems/?max_results=3",
     ...                  headers={'X-Auth-Token': SAPI_TOKEN})
     >>> print(r.headers["Content-Type"])   # doctest: +SKIP
-    application/vnd.dwave.sapi.problems+json; version=2.1.0; charset=utf-8
+    application/vnd.dwave.sapi.problems+json; version=3.0.0; charset=utf-8
 
 
 .. |general error responses| replace:: In addition to generic client and server

--- a/docs/quantum_research/solver_properties_specific.rst
+++ b/docs/quantum_research/solver_properties_specific.rst
@@ -738,7 +738,8 @@ Working-Graph Changes
 The :ref:`qpu_graph_changes_table` table identifies changes to the
 :ref:`working graphs <topologies_working_graph>` for the generally available QPU
 solvers. A QPU solver's current ``graph_id`` is displayed on the
-Leap dashboard for the solver's properties and a problem's parameters.
+Leap dashboard (a solver's Properties and problem's Parameters modals)
+and available through the Ocean SDK.
 
 .. note:: Deployment dates are links to the related release note, if available.
 

--- a/docs/quantum_research/solver_properties_specific.rst
+++ b/docs/quantum_research/solver_properties_specific.rst
@@ -729,3 +729,144 @@ The standard annealing schedule for the QPU is shown in
 
     Standard annealing schedule for the QPU, showing energy changes
     as a function of scaled time.
+
+.. _qpu_graph_changes:
+
+Working-Graph Changes
+=====================
+
+The :ref:`qpu_graph_changes_table` table identifies changes to the
+:ref:`working graphs <topologies_working_graph>` for the generally available QPU
+solvers. A QPU solver's current ``graph_id`` is displayed on the
+Leap dashboard for the solver's properties and a problem's parameters.
+
+.. note:: Deployment dates are links to the related release note, if available.
+
+.. list-table:: Working-Graph Changes
+    :name: qpu_graph_changes_table
+    :header-rows: 1
+
+    *   -   Solver Name
+        -   Deployment Date
+        -   Removed Qubits
+
+    *   -   **Advantage2_system1**
+        -
+        -
+
+    *   -   Advantage2_system1.13
+        -   :ref:`2026-03-18 <adv2_1.13>`
+        -   249
+    
+    *   -   Advantage2_system1.12
+        -   :ref:`2026-03-04 <adv2_1.12>`
+        -   1871, 1895
+
+    *   -   Advantage2_system1.11
+        -   :ref:`2026-01-28 <adv2_1.11>`
+        -   380, 381, 441, 577, 4202, 4226, 4237
+        
+    *   -   Advantage2_system1.10
+        -   :ref:`2025-12-15 <adv2_1.10>`
+        -   2782
+        
+    *   -   Advantage2_system1.9
+        -   :ref:`2025-12-09 <adv2_1.9>`
+        -   2049
+        
+    *   -   Advantage2_system1.8
+        -   :ref:`2025-11-19 <adv2_1.8>`
+        -   484
+        
+    *   -   Advantage2_system1.7
+        -   :ref:`2025-11-04 <adv2_1.7>`
+        -   510
+        
+    *   -   Advantage2_system1.6
+        -   :ref:`2025-09-02 <ref:adv2_1.6>`
+        -   3122
+        
+    *   -   Advantage2_system1.5
+        -   :ref:`2025-08-07 <adv2_1.5>`
+        -   4058, 4082
+        
+    *   -   Advantage2_system1.4
+        -   :ref:`2025-07-16 <adv2_1.4>`
+        -   769
+        
+    *   -   Advantage2_system1.3
+        -   :ref:`2025-06-20 <adv2_1.3>`
+        -   2838
+        
+    *   -   Advantage2_system1.2
+        -   :ref:`2025-06-17 <adv2_1.2>`
+        -   1283, 4686
+        
+    *   -   Advantage2_system1.1
+        -   :ref:`2025-05-20 <doc-898>`
+        -   First solver release
+        
+    *   -   **Advantage2_system4**
+        -
+        -
+
+    *   -   Advantage2_system4.3
+        -   :ref:`2025-12-22 <adv2_4.3>`
+        -   840
+        
+    *   -   Advantage2_system4.1
+        -   :ref:`2025-11-03 <adv2_na_east_new>`
+        -   First solver release
+        
+    *   -   **Advantage_system6**
+        -
+        -
+
+    *   -   Advantage_system6.4
+        -   :ref:`2024-02-28 <isi_6.4>`
+        -   104, 119
+        
+    *   -   Advantage_system6.3
+        -   :ref:`2023-10-18 <isi_6.3>`
+        -   Only couplers removed
+        
+    *   -   Advantage_system6.2
+        -   :ref:`2023-05-31 <adv6.2>`
+        -   727, 742
+        
+    *   -   Advantage_system6.1
+        -   :ref:`2022-05-12 <isi_new_qc>`
+        -   First solver release
+
+    *   -   **Advantage_system4**
+        -
+        -
+
+    *   -   Advantage_system4.1
+        -   :ref:`2021-10-05 <adv4_perf_update>`
+        -   First solver release
+        
+    *   -   **Advantage2_research1**
+        -
+        -
+
+    *   -   Advantage2_research1.5
+        -   2025-12-18
+        -   Only couplers removed
+
+    *   -   Advantage2_research1.4
+        -   2025-11-26
+        -   5, 11, 29, 34, 41, 53, 58, 70, 89, 94, 106, 113, 118,
+            125, 130, 131, 1134, 1140, 1141, 1146, 1153, 1164
+            
+    *   -   Advantage2_research1.3
+        -   2025-10-21
+        -   44, 466, 550, 622, 686, 735, 912, 1170, 1231
+        
+    *   -   Advantage2_research1.2
+        -   2025-09-10
+        -   90, 434, 663, 693, 780, 868
+        
+    *   -   Advantage2_research1.1
+        -   2025-08-14
+        -   First solver release

--- a/docs/quantum_research/solver_properties_specific.rst
+++ b/docs/quantum_research/solver_properties_specific.rst
@@ -738,7 +738,7 @@ Working-Graph Changes
 The :ref:`qpu_graph_changes_table` table identifies changes to the
 :ref:`working graphs <topologies_working_graph>` for the generally available QPU
 solvers. A QPU solver's current ``graph_id`` is displayed on the
-Leap dashboard (a solver's Properties and problem's Parameters modals)
+Leap dashboard (a solver's **Properties** and a problem's **Parameters** modals)
 and available through the Ocean SDK.
 
 .. list-table:: Working-Graph Changes
@@ -782,7 +782,7 @@ and available through the Ocean SDK.
         -   510
         
     *   -   Advantage2_system1.6
-        -   :ref:`2025-09-02 <ref:adv2_1.6>`
+        -   :ref:`2025-09-02 <adv2_1.6>`
         -   3122
         
     *   -   Advantage2_system1.5

--- a/docs/quantum_research/solver_properties_specific.rst
+++ b/docs/quantum_research/solver_properties_specific.rst
@@ -741,14 +741,12 @@ solvers. A QPU solver's current ``graph_id`` is displayed on the
 Leap dashboard (a solver's Properties and problem's Parameters modals)
 and available through the Ocean SDK.
 
-.. note:: Deployment dates are links to the related release note, if available.
-
 .. list-table:: Working-Graph Changes
     :name: qpu_graph_changes_table
     :header-rows: 1
 
     *   -   Solver Name
-        -   Deployment Date
+        -   Deployment Date\ [#]_
         -   Removed Qubits
 
     *   -   **Advantage2_system1**
@@ -871,3 +869,5 @@ and available through the Ocean SDK.
     *   -   Advantage2_research1.1
         -   2025-08-14
         -   First solver release
+
+.. [#] Deployment dates are links to the related release note, if available.


### PR DESCRIPTION
HTML is available as follows:

* [SAPI REST Interface](https://output.circle-artifacts.com/output/job/d3f17695-c78b-4bdf-b1cb-c469d26319e2/artifacts/0/docs/_build/html/leap_sapi/sapi_rest.html#leap-sapi-rest)
     * The v3 ``Accept`` header is required, so now it is in the body of the resource description. A dropdown at the end of the resource descrption states that SAPI resource representation v2/2.1 isn't supported, just in case users haven't changed their code.
     * Added 415 UNSUPPORTED MEDIA TYPE for invalid version in the ``Accept`` header.
* [Working-Graph Changes](https://output.circle-artifacts.com/output/job/d3f17695-c78b-4bdf-b1cb-c469d26319e2/artifacts/0/docs/_build/html/quantum_research/solver_properties_specific.html#working-graph-changes)
     * ``graph_id`` is ephemeral, so working-graph changes are identified by deployment date.