### PR TITLE
docs(sapi): fix Accept header in Cancel Problem by ID section

### DIFF
--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -1087,7 +1087,7 @@ To cancel a previously submitted problem, make an HTTP DELETE request to the
 ``problems/<problem_id>`` endpoint.
 
 The ``Accept`` header should be set to
-``application/vnd.dwave.sapi.problems+json; version=3``.
+``application/vnd.dwave.sapi.problem+json; version=3``.
 
 The request should contain no body.
 


### PR DESCRIPTION
The "Cancel a Problem by ID" section states the Accept header should use `application/vnd.dwave.sapi.problems+json; version=3` (plural), but the code examples in the same section use `application/vnd.dwave.sapi.problem+json; version=3` (singular). Fixed the prose to match the code examples and the single-problem endpoint semantics.

Fixes #442
