### PR TITLE
docs(sapi_rest): fix singular media type in Cancel-by-ID Accept header prose

### DIFF
--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -1087,7 +1087,7 @@ To cancel a previously submitted problem, make an HTTP DELETE request to the
 ``problems/<problem_id>`` endpoint.
 
 The ``Accept`` header should be set to
-``application/vnd.dwave.sapi.problems+json; version=3``.
+``application/vnd.dwave.sapi.problem+json; version=3``.
 
 The request should contain no body.
 


### PR DESCRIPTION
Closes #442. See source for details; one-line fix aligning the prose with the adjacent Python and cURL examples, which already use the singular `application/vnd.dwave.sapi.problem+json; version=3`.