### PR TITLE
Add Generative and Discriminative Modeling section

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -11,6 +11,7 @@
                 ket: ["{|#1\\rangle}",1],
                 ip: ["{\\langle#1,#2\\rangle}",2],
                 tr: "\\operatorname{tr}",
+                Tr: "\\operatorname{Tr}",
                 argmax: "\\mathop{\\arg\\,\\max}\\limits",
                 argmin: "\\mathop{\\arg\\,\\min}\\limits"
             }

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -15,7 +15,8 @@ Bibliography
 .. [Ada2015]
     Steven H. Adachi, Maxwell P. Henderson.
     "Application of Quantum Annealing to Training of Deep Neural Networks."
-    arXiv:1510.06356. 21 Oct 2015. https://arxiv.org/abs/1510.06356
+   21 Oct 2015
+   https://arxiv.org/abs/1510.06356
 
 .. [Ahu2000]
     Ahuja, R. K., Orlin, J. B., and Sharma, D.
@@ -29,12 +30,13 @@ Bibliography
     "Quantum Boltzmann Machine."
     Phys. Rev. X 8, 021050.
     23 May, 2018
-    DOI: https://doi.org/10.1103/PhysRevX.8.021050
+    https://doi.org/10.1103/PhysRevX.8.021050
 
 .. [Ami2015]
     Mohammad H. Amin
     "Searching for quantum speedup in quasistatic quantum annealers."
-    Phys. Rev. A 92, 052323 – Published 19 November 2015
+    Phys. Rev. A 92, 052323
+    19 November 2015
     https://doi.org/10.1103/PhysRevA.92.052323
     arXiv:1503.04216v2
 
@@ -54,20 +56,21 @@ Bibliography
 .. [Bac2002]
     Fahiem Bacchus, Xinguang Chen, Peter van Beek, and Toby Walsh.
     "Binary vs. non-binary constraints."
-    Artificial Intelligence 140 (2002) 1–37. 17 January 2001.
+    Artificial Intelligence 140 (2002) 1-37. 17 January 2001.
     https://www.sciencedirect.com/science/article/pii/S0004370202002102
 
 .. [Bal1987]
     Ballard, Dana H.
     "Modular learning in neural networks."
-    AAAI'87: Proceedings of the sixth National conference on Artificial intelligence - Volume 1
-    Pages 279 - 284
+    AAAI'87: Proceedings of the sixth National conference on Artificial
+    intelligence, Volume 1, Pages 279 - 284
     13 July 1987
 
 .. [Bar1982]
     F. Barahona.
     "On the Computational Complexity of Ising Spin Glass Models."
-    J. Phys. A, 15, 3241-3253, 1982.
+    J. Phys. A, 15, 3241-3253
+    1982
 
 .. [Bas2020]
     Gideon Bass, Max Henderson, Joshua Heath, Joseph Dulny III.
@@ -77,10 +80,11 @@ Bibliography
     https://arxiv.org/abs/2001.06079
 
 .. [Ben2013]
-    Bengio, Yoshua and L{\'e}onard, Nicholas and Courville, Aaron.
-    "Estimating or propagating gradients through stochastic neurons for conditional computation."
+    Bengio, Yoshua and Léonard, Nicholas and Courville, Aaron.
+    "Estimating or propagating gradients through stochastic neurons for
+    conditional computation."
     2013
-    arXiv preprint arXiv:1308.3432
+    arXiv:1308.3432
 
 .. [Ben2017]
     Marcello Benedetti, John Realpe-G´omez, Rupak Biswas,
@@ -152,7 +156,7 @@ Bibliography
 .. [Boo2016]
     Kelly Boothby, Andrew D. King, and Aidan Roy.
     "Fast clique minor generation in Chimera qubit connectivity graphs."
-    *Quantum Inf Process* Volume 15, Issue 1,  pp 495–508. January 2016.
+    *Quantum Inf Process* Volume 15, Issue 1,  pp 495-508. January 2016.
     https://link.springer.com/article/10.1007/s11128-015-1150-6
     https://arxiv.org/abs/1507.04774
 
@@ -227,10 +231,10 @@ Bibliography
     *arXiv*. 10 Jun 2014. https://arxiv.org/abs/1406.2741
 
 .. [Cal2019]
-    Caldeira, Jo{\~a}o and Job, Joshua and Adachi, Steven H and Nord, Brian and Perdue, Gabriel N
+    Caldeira, João and Job, Joshua and Adachi, Steven H and Nord, Brian and Perdue, Gabriel N
     "Restricted Boltzmann Machines for galaxy morphology classification with a quantum annealer."
     2019
-    arXiv preprint arXiv:1911.06259
+    arXiv:1911.06259
 
 .. [Cas2002]
     Casella, George and Berger, Roger L.
@@ -300,8 +304,9 @@ Bibliography
     https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
 
 .. [Dao2022]
-    Dao, Tri and Fu, Dan and Ermon, Stefano and Rudra, Atri and R{\'e}, Christopher.
-    "Flashattention: Fast and memory-efficient exact attention with iO-awareness."
+    Dao, Tri and Fu, Dan and Ermon, Stefano and Rudra, Atri and Ré, Christopher.
+    "FlashAttention: Fast and Memory-Efficient Exact Attention with
+    IO-Awareness."
     Advances in neural information processing systems Vol 35 pages 16344--16359
     2022
 
@@ -329,7 +334,8 @@ Bibliography
 
 .. [Den2012]
     Deng, Li.
-    "The MNIST Database of Handwritten Digit Images for Machine Learning Research [Best of the Web]."
+    "The MNIST Database of Handwritten Digit Images for Machine Learning
+    Research [Best of the Web]."
     IEEE Signal Processing Magazine, vol. 29, no. 6, pp. 141-142.
     Nov. 2012
 
@@ -348,7 +354,7 @@ Bibliography
     Dobruschin, PL.
     "The Description of a Random Field by Means of Conditional Probabilities and
     Conditions of Its Regularity."
-    Theory of Probability \& Its Applications. Vol. 13, Iss. 2.
+    Theory of Probability & Its Applications. Vol. 13, Iss. 2.
     1968
 
 .. [Dou2015]
@@ -556,7 +562,7 @@ Bibliography
     Hinton, Geoffrey.
     "A Practical Guide to Training Restricted Boltzmann Machines."
     August 2010
-    DOI:10.1007/978-3-642-35289-8_32
+    doi: 10.1007/978-3-642-35289-8_32
 
 .. [Hin2012]
     Geoffrey E. Hinton.
@@ -601,7 +607,7 @@ Bibliography
     Jang, Eric and Gu, Shixiang and Poole, Ben.
     "Categorical reparameterization with gumbel-softmax."
     2016
-    arXiv preprint arXiv:1611.01144
+    arXiv:1611.01144
 
 .. [Jas2019]
     Tim Jaschek, Marko Bucyk, and Jaspreet S. Oberoi.
@@ -681,13 +687,13 @@ Bibliography
     "Quantum variational autoencoder."
     Quantum Sci. Technol. 4 014001
     2018
-    DOI 10.1088/2058-9565/aada1f
+    doi: 10.1088/2058-9565/aada1f
 
 .. [Kin2013]
     Kingma, Diederik P.
     "Auto-encoding variational bayes."
     2013
-    arXiv preprint arXiv:1312.6114
+    arXiv:1312.6114
 
 .. [Kin2014]
     A. D. King and C. C. McGeoch.
@@ -752,7 +758,7 @@ Bibliography
     and Zhou, Hengyun and Bravo, Rodrigo Araiza and others.
     "Large-scale quantum reservoir learning with an analog quantum computer."
     2024
-    arXiv preprint arXiv:1609.02907
+    arXiv:1609.02907
 
 .. [Kun2026]
     Kunugi, Hayato and Rahmani, Mohsen and Iyama, Yosuke and Hirono, Yutaro and
@@ -761,7 +767,7 @@ Bibliography
     "Molecular Design beyond Training Data with Novel Extended Objective Functionals
     of Generative AI Models Driven by Quantum Annealing Computer."
     2026
-    arXiv preprint arXiv:2602.15451
+    arXiv:2602.15451
 
 .. [Kur2020]
     Kurowski K., Weglarz J., Subocz M., Rozycki R., Waligora G. (2020)
@@ -784,7 +790,7 @@ Bibliography
     July 1963
 
 .. [Lay2024]
-    Laydevant, J{\'e}r{\'e}mie and Markovi{\'c}, Danijela and Grollier, Julie.
+    Laydevant, Jérémie and Markovic, Danijela and Grollier, Julie.
     "Training an Ising machine with equilibrium propagation."
     Nat Commun 15, 3671
     2024
@@ -873,7 +879,7 @@ Bibliography
     Maddison, Chris J and Mnih, Andriy and Teh, Yee Whye.
     "The concrete distribution: A continuous relaxation of discrete random variables."
     2016
-    arXiv preprint arXiv:1611.00712
+    arXiv:1611.00712
 
 .. [Man1960]
     Alan S. Manne.
@@ -926,7 +932,7 @@ Bibliography
 .. [Met1953]
     Metropolis, Nicholas and Rosenbluth, Arianna W and Rosenbluth, Marshall N and
     Teller, Augusta H and Teller, Edward.
-    Equation of state calculations by fast computing machines
+    "Equation of state calculations by fast computing machines."
     The journal of chemical physics 21, 1087
     1953
     doi: 10.1063/1.1699114
@@ -936,7 +942,7 @@ Bibliography
     "Quantum circuit learning."
     Phys. Rev. A 98, 032309
     10 September, 2018
-    DOI: https://doi.org/10.1103/PhysRevA.98.032309
+    doi: https://doi.org/10.1103/PhysRevA.98.032309
 
 .. [Mni2021]
     Susan M. Mniszewski, Pavel A. Dub, Sergei Tretiak, Petr M. Anisimov,
@@ -989,7 +995,7 @@ Bibliography
 
 .. [Nea]
     Neal, Radford M.
-    Annealed importance sampling.
+    "Annealed importance sampling."
     Statistics and Computing 11, 125-139
     2001.
     https://doi.org/10.1023/A:1008923215028
@@ -1062,16 +1068,6 @@ Bibliography
     "Parallel quantum annealing."
     Sci Rep 12, 4499 (2022).
     https://doi.org/10.1038/s41598-022-08394-8
-
-.. Kevin's lit review but unusued
-
-    .. [Pel2025]
-        Pelofske, Elijah.
-        "Comparing three generations of D-Wave quantum annealers for minor embedded combinatorial
-        optimization problems."
-        Quantum Sci. Technol. 10 025025
-        2025
-        DOI 10.1088/2058-9565/adb029
 
 .. [Per2012]
     Alejandro Perdomo-Ortiz, Neil Dickson, Marshall Drew-Brook, Geordie Rose,
@@ -1209,9 +1205,10 @@ Bibliography
 
 .. [Sce2024]
     Scellier, Benjamin
-    "Quantum equilibrium propagation: Gradient-descent training of quantum systems."
+    "Quantum equilibrium propagation: Gradient-descent training of quantum
+    systems."
     2024
-    arXiv preprint arXiv:2406.00879
+    arXiv:2406.00879
 
 .. [Sch2009]
     Nicol N. Schraudolph and Dmitry Kamenetsky.
@@ -1229,9 +1226,10 @@ Bibliography
 
 .. [Smo1986]
     Smolensky, Paul.
-    "Information Processing in Dynamical Systems: Foundations of Harmony Theory."
+    "Information Processing in Dynamical Systems: Foundations of Harmony
+    Theory."
     1986
-    Doi: https://doi.org/10.7551/mitpress/5236.003.0009
+    doi: https://doi.org/10.7551/mitpress/5236.003.0009
 
 .. [Spa1991]
     Susan B. Spalti, et al.
@@ -1316,12 +1314,13 @@ Bibliography
     Pages 1747--1756
     2016
     arXiv:1601.06759
-    doi:10.48550/arXiv.1601.06759
+    doi: 10.48550/arXiv.1601.06759
 
 .. [Van2017]
     Van Den Oord, Aaron and Vinyals, Oriol and others.
     "Neural discrete representation learning."
-    NIPS'17: Proceedings of the 31st International Conference on Neural Information Processing Systems
+    NIPS'17: Proceedings of the 31st International Conference on Neural
+    Information Processing Systems
     Pages 6309 - 6318
     04 December 2017
 
@@ -1329,7 +1328,8 @@ Bibliography
     Vaswani, Ashish and Shazeer, Noam and Parmar, Niki and Uszkoreit, Jakob and
     Jones, Llion and Gomez, Aidan N and Kaiser, {\L}ukasz and Polosukhin, Illia.
     "Attention is all you need."
-    NIPS'17: Proceedings of the 31st International Conference on Neural Information Processing Systems
+    NIPS'17: Proceedings of the 31st International Conference on Neural
+    Information Processing Systems
     Pages 6000 - 6010
     04 December 2017
 
@@ -1402,14 +1402,15 @@ Bibliography
 
 .. [Wie2022]
     Wierichs, David and Izaac, Josh and Wang, Cody and Lin, Cedric Yen-Yu.
+    "General parameter-shift rules for quantum gradients."
     Quantum 6, 677
-    Verein zur F{\"o}rderung des Open Access Publizierens in den Quantenwissenschaften.
     2022
     https://doi.org/10.22331/q-2022-03-30-677
 
 .. [Wil1992]
     Williams, Ronald J
-    "Simple statistical gradient-following algorithms for connectionist reinforcement learning."
+    "Simple statistical gradient-following algorithms for connectionist
+    reinforcement learning."
     Machine Learning, Volume 8, Issue 3-4, Pages 229 - 256
     01 May 1992
     https://doi.org/10.1007/BF00992696
@@ -1453,7 +1454,7 @@ Bibliography
     Zhao, Shengjia and Song, Jiaming and Ermon, Stefano.
     "InfoVAE: Information maximizing variational autoencoders."
     2017
-    arXiv preprint arXiv:1706.02262
+    arXiv:1706.02262
 
 .. [Zha2025]
     Zhang, Hao and Kamenev, Alex.

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -993,7 +993,7 @@ Bibliography
     https://1qbit.com/our-thinking/research-papers
     arXiv:1708.03439
 
-.. [Nea]
+.. [Nea2001]
     Neal, Radford M.
     "Annealed importance sampling."
     Statistics and Computing 11, 125-139

--- a/docs/bibliography.rst
+++ b/docs/bibliography.rst
@@ -4,6 +4,14 @@
 Bibliography
 ============
 
+.. [Ack1985]
+    Ackley, David H and Hinton, Geoffrey E and Sejnowski, Terrence J.
+    "A learning algorithm for boltzmann machines."
+    Cognitive Science
+    Volume 9, Issue 1, Pages 147-169.
+    1985
+    https://doi.org/10.1016/S0364-0213(85)80012-4
+
 .. [Ada2015]
     Steven H. Adachi, Maxwell P. Henderson.
     "Application of Quantum Annealing to Training of Deep Neural Networks."
@@ -14,6 +22,14 @@ Bibliography
     "Very large-scale neighborhood search."
     International Transactions in Operational Research 7 (4-5): 301-317. 2000.
     https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1475-3995.2000.tb00201.x
+
+.. [Ami2018]
+    Amin, Mohammad H and Andriyash, Evgeny and Rolfe, Jason and Kulchytskyy,
+    Bohdan and Melko, Roger.
+    "Quantum Boltzmann Machine."
+    Phys. Rev. X 8, 021050.
+    23 May, 2018
+    DOI: https://doi.org/10.1103/PhysRevX.8.021050
 
 .. [Ami2015]
     Mohammad H. Amin
@@ -41,6 +57,13 @@ Bibliography
     Artificial Intelligence 140 (2002) 1–37. 17 January 2001.
     https://www.sciencedirect.com/science/article/pii/S0004370202002102
 
+.. [Bal1987]
+    Ballard, Dana H.
+    "Modular learning in neural networks."
+    AAAI'87: Proceedings of the sixth National conference on Artificial intelligence - Volume 1
+    Pages 279 - 284
+    13 July 1987
+
 .. [Bar1982]
     F. Barahona.
     "On the Computational Complexity of Ising Spin Glass Models."
@@ -52,6 +75,12 @@ Bibliography
     Quantum Mach. Intell. 3, 10 (2021).
     https://doi.org/10.1007/s42484-021-00039-9
     https://arxiv.org/abs/2001.06079
+
+.. [Ben2013]
+    Bengio, Yoshua and L{\'e}onard, Nicholas and Courville, Aaron.
+    "Estimating or propagating gradients through stochastic neurons for conditional computation."
+    2013
+    arXiv preprint arXiv:1308.3432
 
 .. [Ben2017]
     Marcello Benedetti, John Realpe-G´omez, Rupak Biswas,
@@ -155,6 +184,12 @@ Bibliography
     *Discrete Optimization* 5, no. 2 (May 2008): 501-529.
     https://doi.org/10.1016/j.disopt.2007.02.001.
 
+.. [Boy2004]
+    Boyd, Stephen and Vandenberghe, Lieven.
+    "Convex Optimization."
+    Cambridge: Cambridge University Press.
+    2004
+
 .. [Boy2007]
     S. Boyd and A. Mutapcic.
     “Subgradient methods.” 2007.
@@ -191,6 +226,19 @@ Bibliography
     "A practical heuristic for finding graph minors."
     *arXiv*. 10 Jun 2014. https://arxiv.org/abs/1406.2741
 
+.. [Cal2019]
+    Caldeira, Jo{\~a}o and Job, Joshua and Adachi, Steven H and Nord, Brian and Perdue, Gabriel N
+    "Restricted Boltzmann Machines for galaxy morphology classification with a quantum annealer."
+    2019
+    arXiv preprint arXiv:1911.06259
+
+.. [Cas2002]
+    Casella, George and Berger, Roger L.
+    "Statistical Inference."
+    Chapman and Hall/CRC.
+    2024
+    https://doi.org/10.1201/9781003456285
+
 .. [Cha2019]
     Nicholas Chancellor.
     "Domain wall encoding of discrete variables for quantum annealing and QAOA."
@@ -208,6 +256,19 @@ Bibliography
     "Tutorial: Calibration refinement in quantum annealing".
     20 April 2023.
     https://arxiv.org/abs/2304.10352
+
+.. [Cho2008]
+    Choi, Vicky
+    "Minor-embedding in adiabatic quantum computation: I. The parameter setting problem."
+    Quantum Inf Process 7, 193-209
+    2008
+    https://doi.org/10.1007/s11128-008-0082-9
+
+.. [Chr1995]
+    Chrisley, Ronald.
+    "New directions in cognitive science."
+    Proceedings of the international symposium, Saariselka
+    1995
 
 .. [Coh2020]
     Jeffrey Cohen, Alex Khan, Clark Alexander
@@ -238,6 +299,12 @@ Bibliography
     Programming the D-Wave: Map Coloring Problem. November 2013.
     https://www.dwavesys.com/media/htfgw5bk/map-coloring-wp2.pdf
 
+.. [Dao2022]
+    Dao, Tri and Fu, Dan and Ermon, Stefano and Rudra, Atri and R{\'e}, Christopher.
+    "Flashattention: Fast and memory-efficient exact attention with iO-awareness."
+    Advances in neural information processing systems Vol 35 pages 16344--16359
+    2022
+
 .. [Das2019]
     Samudra Dasgupta, Arnab Banerjee.
     "Quantum Annealing Algorithm for Expected Shortfall based Dynamic Asset
@@ -260,6 +327,12 @@ Bibliography
     Morgan Kaufmann.
     2003.
 
+.. [Den2012]
+    Deng, Li.
+    "The MNIST Database of Handwritten Digit Images for Machine Learning Research [Best of the Web]."
+    IEEE Signal Processing Magazine, vol. 29, no. 6, pp. 141-142.
+    Nov. 2012
+
 .. [Dic2013]
     N. G. Dickson et al.
     “Thermally assisted quantum annealing of a 16-qubit problem.”
@@ -270,6 +343,13 @@ Bibliography
     Yongcheng Ding, Xi Chen, Lucas Lamata, Enrique Solano, Mikel Sanz
     "Implementation of a Hybrid Classical-Quantum Annealing Algorithm
     for Logistic Network Design." arXiv:1906.10074 [quant-ph]
+
+.. [Dob1968]
+    Dobruschin, PL.
+    "The Description of a Random Field by Means of Conditional Probabilities and
+    Conditions of Its Regularity."
+    Theory of Probability \& Its Applications. Vol. 13, Iss. 2.
+    1968
 
 .. [Dou2015]
     Adam Douglass, Andrew D. King, and Jack Raymond.
@@ -327,6 +407,11 @@ Bibliography
     D-Wave Technical Report, no. 14-1048A-A, 2020.
     https://www.dwavesys.com/media/m2xbmlhs/14-1048a-a_d-wave_hybrid_solver_service_plus_advantage_technology_update.pdf
 
+.. [Dwave8]
+    "Computational Power Consumption and Speedup."
+    D-Wave Technical Report, no. 14-1005A-D, 2017.
+    https://www.dwavequantum.com/media/ivelyjij/14-1005a_d_wp_computational_power_consumption_and_speedup.pdf
+
 .. [Efr1982]
     B. Efron, (1982).
     "The Jackknife, the Bootstrap, and Other Resampling Plans."
@@ -339,6 +424,14 @@ Bibliography
     "Financial Portfolio Management using D-Wave’s Quantum Optimizer:
     The Case of Abu Dhabi Securities Exchange."
 
+.. [Eri2015]
+    Erin Liong, Venice and Lu, Jiwen and Wang, Gang and Moulin, Pierre and Zhou, Jie.
+    "Deep hashing for compact binary codes learning."
+    IEEE Conference on Computer Vision and Pattern Recognition (CVPR), Boston, MA
+    pp. 2475-2483
+    2015
+    doi: 10.1109/CVPR.2015.7298862.
+
 .. [Flo2017]
     Florian Neukart, Gabriele Compostella, Christian Seidel, David von Dollen,
     Sheir Yarkoni, and Bob Parney.
@@ -349,6 +442,20 @@ Bibliography
     Francesca Rossi, Charles Petrie, and Vasant Dhar.
     "On the Equivalence of Constraint Satisfaction Problems."
     Technical Report ACTAI-222-89, MCC, Austin, TX. 1989.
+
+.. [Fuk1979]
+    Fukushima, Kunihiko
+    Neural network model for a mechanism of pattern recognition un affected by
+    shift in position-neocognitron.
+    IEICE Technical Report, A Vol 62 Num 10 pages 658--665
+    1979
+
+.. [Gey1991]
+    Geyer, Charles J
+    Markov Chain Monte Carlo Maximum Likelihood.
+    Interface Foundation of North America
+    1991
+    https://conservancy.umn.edu/handle/11299/58440
 
 .. [Glo1990]
     Glover, F.
@@ -362,6 +469,13 @@ Bibliography
     of Quadratic Unconstrained Binary Optimization Problems."
     arXiv:1705.09545.
     https://arxiv.org/abs/1705.09545
+
+.. [Gly1990]
+    Glynn, Peter W
+    "Likelihood ratio gradient estimation for stochastic systems."
+    Communications of the ACM, Volume 33, Issue 10, Pages 75 - 84
+    01 October 1990
+    https://doi.org/10.1145/84537.84552
 
 .. [Gog2004]
     Gogate V. and R. Dechter.
@@ -385,6 +499,12 @@ Bibliography
     P. Grassberger, (2008).
     "Entropy Estimates from Insufficient Samplings."
     arXiv:physics/0307138v2.
+
+.. [Gu2024]
+    Gu, Albert and Dao, Tri.
+    "Linear-time sequence modeling with selective state spaces."
+    First conference on language modeling
+    2024
 
 .. [Gue2018]
     G. G. Guerreschi, A. Y. Matsuura.
@@ -425,10 +545,23 @@ Bibliography
     on a Quantum Annealer."
     arXiv:2201.01543 [cs.SI]
 
+.. [Hin2002]
+    Hinton, Geoffrey E.
+    "Training Products of Experts by Minimizing Contrastive Divergence."
+    Neural Computation, vol. 14, no. 8, pp. 1771-1800.
+    1 Aug. 2002
+    doi: 10.1162/089976602760128018.
+
+.. [Hin2010]
+    Hinton, Geoffrey.
+    "A Practical Guide to Training Restricted Boltzmann Machines."
+    August 2010
+    DOI:10.1007/978-3-642-35289-8_32
+
 .. [Hin2012]
     Geoffrey E. Hinton.
     "A Practical Guide to Training Restricted Boltzmann Machines."
-    Pages 599–619, Springer, Berlin, Heidelberg.
+    Pages 599-619, Springer, Berlin, Heidelberg.
     2012.
     https://www.cs.toronto.edu/~hinton/absps/guideTR.pdf
 
@@ -451,11 +584,24 @@ Bibliography
     NO. 6. June 2011.
     https://ieeexplore.ieee.org/document/5444874/
 
+.. [Isi1925]
+    Ising, Ernst.
+    "Beitrag zur Theorie des Ferromagnetismus."
+    Z. Physik 31, 253-258
+    1925
+    https://doi.org/10.1007/BF02980577
+
 .. [Izq2022]
     Zoe Gonzalez Izquierdo, Shon Grabbe, Husni Idris, Zhihui Wang,
     Jeffrey Marshall, and Eleanor Rieffel.
     "The Advantage of pausing: parameter setting for quantum annealers."
     arXiv:2205.12936 [quant-ph]
+
+.. [Jan2016]
+    Jang, Eric and Gu, Shixiang and Poole, Ben.
+    "Categorical reparameterization with gumbel-softmax."
+    2016
+    arXiv preprint arXiv:1611.01144
 
 .. [Jas2019]
     Tim Jaschek, Marko Bucyk, and Jaspreet S. Oberoi.
@@ -491,8 +637,6 @@ Bibliography
     M. W. Johnson et al. "Quantum annealing with manufactured spins."
     *Nature* 473 (May 12, 2011), pp. 194--198.
 
-
-
 .. [Jor2011]
     Stephen Jordan.
     "Quantum Algorithm Zoo."
@@ -503,6 +647,13 @@ Bibliography
     "A quantum annealing approach for Boolean Satisfiability problem."
     Design Automation Conference (DAC), 2016 53nd ACM/EDAC/IEEE.
     https://ieeexplore.ieee.org/document/7544390/
+
+.. [Kak1995]
+    Kak, Subhash C.
+    "Quantum Neural Computing."
+    Advances in Imaging and Electron Physics, Volume 94, Pages 259-313
+    1995
+    https://doi.org/10.1016/S1076-5670(08)70147-2
 
 .. [Kal2019]
     Angad Kalra, Faisal Qureshi, Michael Tisi.
@@ -523,6 +674,20 @@ Bibliography
     combinatorial optimization problems: A state-of-the-art."
     European Journal of Operational Research 296, No. 2 (January 2022): 393-422. 
     https://doi.org/10.1016/j.ejor.2021.04.032
+
+.. [Kho2018]
+    Khoshaman, Amir and Vinci, Walter and Denis, Brandon and Andriyash, Evgeny
+    and Sadeghi, Hossein and Amin, Mohammad H.
+    "Quantum variational autoencoder."
+    Quantum Sci. Technol. 4 014001
+    2018
+    DOI 10.1088/2058-9565/aada1f
+
+.. [Kin2013]
+    Kingma, Diederik P.
+    "Auto-encoding variational bayes."
+    2013
+    arXiv preprint arXiv:1312.6114
 
 .. [Kin2014]
     A. D. King and C. C. McGeoch.
@@ -581,6 +746,23 @@ Bibliography
     *arXiv:1611.04528*. 14 Nov 2016.
     https://arxiv.org/abs/1611.04528
 
+.. [Kor2024]
+    Kornja{\v{c}}a, Milan and Hu, Hong-Ye and Zhao, Chen and Wurtz, Jonathan and
+    Weinberg, Phillip and Hamdan, Majd and Zhdanov, Andrii and Cantu, Sergio H
+    and Zhou, Hengyun and Bravo, Rodrigo Araiza and others.
+    "Large-scale quantum reservoir learning with an analog quantum computer."
+    2024
+    arXiv preprint arXiv:1609.02907
+
+.. [Kun2026]
+    Kunugi, Hayato and Rahmani, Mohsen and Iyama, Yosuke and Hirono, Yutaro and
+    Suma, Akira and Woolway, Matthew and Vargas-Calder{\'o}n, Vladimir and Kim,
+    William and Chern, Kevin and Amin, Mohammad and others.
+    "Molecular Design beyond Training Data with Novel Extended Objective Functionals
+    of Generative AI Models Driven by Quantum Annealing Computer."
+    2026
+    arXiv preprint arXiv:2602.15451
+
 .. [Kur2020]
     Kurowski K., Weglarz J., Subocz M., Rozycki R., Waligora G. (2020)
     "Hybrid Quantum Annealing Heuristic Method for Solving Job Shop Scheduling
@@ -595,11 +777,31 @@ Bibliography
     non-uniform driver Hamiltonians."
     Phys. Rev. A 96, 042322 (2017)   https://arxiv.org/abs/1708.03049
 
+.. [Law1963]
+    Lawler, Eugene L.
+    "The Quadratic Assignment Problem."
+    Management Science, INFORMS, vol. 9(4), pages 586-599.
+    July 1963
+
+.. [Lay2024]
+    Laydevant, J{\'e}r{\'e}mie and Markovi{\'c}, Danijela and Grollier, Julie.
+    "Training an Ising machine with equilibrium propagation."
+    Nat Commun 15, 3671
+    2024
+    https://doi.org/10.1038/s41467-024-46879-4
+
 .. [Lec2006]
     Yann LeCun.
     "Predicting structured outputs."
     A Tutorial on Energy-Based Learning, MIT Press.
     2006.
+
+.. [Ler2008]
+    Le Roux, Nicolas and Bengio, Yoshua.
+    "Representational power of restricted Boltzmann machines and deep belief networks."
+    Neural computation vol. 20, no. 6, pp. 1631-1649
+    June 2008
+    doi: 10.1162/neco.2008.04-07-510
 
 .. [Lev1973]
     Leonid Levin.
@@ -609,6 +811,12 @@ Bibliography
     "A survey of Russian approaches to perebor (brute-force searches)
     algorithms."
     Annals of the History of Computing 6(4),384-400. 1984.
+
+.. [Li2016]
+    Li, Yujia and Swersky, Kevin and Zemel, Rich
+    ICML'15: Proceedings of the 32nd International Conference on Machine Learning
+    Volume 37 Pages 1718 - 1727
+    2016
 
 .. [Li2020]
     Junde Li and Swaroop Ghosh.
@@ -661,6 +869,12 @@ Bibliography
     "Mutual Information, Neural Networks and the Renormalization Group."
     24 Sep 2018. https://arxiv.org/pdf/1704.06279.pdf
 
+.. [Mad2016]
+    Maddison, Chris J and Mnih, Andriy and Teh, Yee Whye.
+    "The concrete distribution: A continuous relaxation of discrete random variables."
+    2016
+    arXiv preprint arXiv:1611.00712
+
 .. [Man1960]
     Alan S. Manne.
     "On the job-shop scheduling problem."
@@ -672,7 +886,7 @@ Bibliography
     "An effective multi-start iterated greedy algorithm to minimize makespan
     for the distributed permutation flowshop scheduling problem with preventative
     maintenance."
-    Expert Systems with Applications 169, No. 114495 (May 2021). 
+    Expert Systems with Applications 169, No. 114495 (May 2021).
     https://doi.org/10.1016/j.eswa.2020.114495
 
 .. [Mar1957]
@@ -702,6 +916,28 @@ Bibliography
     “Practical and efficient multi-view matching.”
     Proceedings of the IEEE International Conference on Computer Vision (2017).
 
+.. [Mas2025]
+    Massar, Serge and Mognetti, Bortolo Matteo.
+    "Equilibrium propagation: the quantum and the thermal cases."
+    Quantum Stud.: Math. Found. 12, 6
+    2025
+    https://doi.org/10.1007/s40509-024-00351-6
+
+.. [Met1953]
+    Metropolis, Nicholas and Rosenbluth, Arianna W and Rosenbluth, Marshall N and
+    Teller, Augusta H and Teller, Edward.
+    Equation of state calculations by fast computing machines
+    The journal of chemical physics 21, 1087
+    1953
+    doi: 10.1063/1.1699114
+
+.. [Mit2018]
+    Mitarai, Kosuke and Negoro, Makoto and Kitagawa, Masahiro and Fujii, Keisuke.
+    "Quantum circuit learning."
+    Phys. Rev. A 98, 032309
+    10 September, 2018
+    DOI: https://doi.org/10.1103/PhysRevA.98.032309
+
 .. [Mni2021]
     Susan M. Mniszewski, Pavel A. Dub, Sergei Tretiak, Petr M. Anisimov,
     Yu Zhang and Christian F. A. Negre.
@@ -710,6 +946,13 @@ Bibliography
     Sci Rep 11, 4099 (2021). https://doi.org/10.1038/s41598-021-83561-x
     https://www.ics.uci.edu/~csp/r140.pdf.
     https://www.nature.com/articles/s41598-021-83561-x
+
+.. [Mon2011]
+    G. Montufar and N. Ay
+    "Refinements of Universal Approximation Results for Deep Belief Networks and Restricted Boltzmann Machines."
+    Neural Computation, vol. 23, no. 5, pp. 1306-1319
+    May 2011
+    doi: 10.1162/NECO_a_00113.
 
 .. [Mon2020]
     Montanaro, A. "Quantum speedup of branch-and-bound algorithms."
@@ -744,10 +987,17 @@ Bibliography
     https://1qbit.com/our-thinking/research-papers
     arXiv:1708.03439
 
+.. [Nea]
+    Neal, Radford M.
+    Annealed importance sampling.
+    Statistics and Computing 11, 125-139
+    2001.
+    https://doi.org/10.1023/A:1008923215028
+
 .. [Nel2010]
     Nielsen, Michael A. and Isaac Chuang.
     "Quantum Computation and Quantum Information."
-    Cambridge University Press. 2010. 
+    Cambridge University Press. 2010.
 
 .. [Nev2012]
     Neven, H., Denchev, V. S., Rose, G., and Macready, W. G.
@@ -793,6 +1043,15 @@ Bibliography
     IEEE Transactions on Computers > Volume: C-26 Issue: 6. 24 May 1976.
     https://ieeexplore.ieee.org/document/1674880/?arnumber=1674880
 
+.. [Pas2019]
+    Paszke, Adam and Gross, Sam and Massa, Francisco and Lerer, Adam and
+    Bradbury, James and Chanan, Gregory and Killeen, Trevor and Lin, Zeming and
+    Gimelshein, Natalia and Antiga, Luca and others.
+    "PyTorch: an imperative style, high-performance deep learning library."
+    Proceedings of the 33rd International Conference on Neural Information
+    Processing Systems, Article No.: 721, Pages 8026 - 8037.
+    December 2019
+
 .. [Pea2008]
     J. Pearl.
     "Probabilistic Reasoning in Intelligent Systems."
@@ -803,6 +1062,16 @@ Bibliography
     "Parallel quantum annealing."
     Sci Rep 12, 4499 (2022).
     https://doi.org/10.1038/s41598-022-08394-8
+
+.. Kevin's lit review but unusued
+
+    .. [Pel2025]
+        Pelofske, Elijah.
+        "Comparing three generations of D-Wave quantum annealers for minor embedded combinatorial
+        optimization problems."
+        Quantum Sci. Technol. 10 025025
+        2025
+        DOI 10.1088/2058-9565/adb029
 
 .. [Per2012]
     Alejandro Perdomo-Ortiz, Neil Dickson, Marshall Drew-Brook, Geordie Rose,
@@ -896,6 +1165,12 @@ Bibliography
     arXiv:1407.2887 [quant-ph] 10 Jul 2014
     https://arxiv.org/abs/1407.2887v1
 
+.. [Rob2004]
+    Robert, Christian P and Casella, George and Casella, George.
+    "Monte Carlo statistical methods."
+    Springer-VerlagBerlin, Heidelberg. ISBN:978-0-387-21239-5
+    01 June 2005
+
 .. [Rol2016]
     Jason Tyler Rolfe. "Discrete Variational Autoencoders." *arXiv:1609.02200*.
     7 Sep 2016. https://arxiv.org/abs/1609.02200
@@ -925,6 +1200,19 @@ Bibliography
     The International Machine Learning Society.
     2007.
 
+.. [Sce2017]
+    Scellier, Benjamin and Bengio, Yoshua.
+    "Bridging the Gap between Energy-Based Models and Backpropagation."
+    Front. Comput. Neurosci. 11:24.
+    2017
+    doi: 10.3389/fncom.2017.00024
+
+.. [Sce2024]
+    Scellier, Benjamin
+    "Quantum equilibrium propagation: Gradient-descent training of quantum systems."
+    2024
+    arXiv preprint arXiv:2406.00879
+
 .. [Sch2009]
     Nicol N. Schraudolph and Dmitry Kamenetsky.
     "Efficient exact inference in planar Ising models."
@@ -932,12 +1220,30 @@ Bibliography
     2009.
     http://users.cecs.anu.edu.au/~dkamen/nips08.pdf.
 
+.. [Sch2015]
+    Schmidhuber, J{\"u}rgen.
+    "Deep learning in neural networks: An overview."
+    Neural Networks Volume 61, Pages 85-117
+    January 2015
+    https://doi.org/10.1016/j.neunet.2014.09.003
+
+.. [Smo1986]
+    Smolensky, Paul.
+    "Information Processing in Dynamical Systems: Foundations of Harmony Theory."
+    1986
+    Doi: https://doi.org/10.7551/mitpress/5236.003.0009
+
 .. [Spa1991]
     Susan B. Spalti, et al.
     "Modeling the satellite placement problem as a network flow problem with one
     side constraint."
     OR Spektrum, Vol. 13, no. 1 (March 1991): 1-14.
     https://doi.org/10.1007/BF01719766
+
+.. [Str2012]
+    Strang, Gilbert.
+    "Linear Algebra and Its Applications."
+    2012
 
 .. [Tai1991]
     E. D. Taillard.
@@ -971,6 +1277,12 @@ Bibliography
     its application to quantum factorization of numbers."
     arXiv:1508.04816 19 Aug 2015 https://arxiv.org/abs/1508.04816
 
+.. [Teh2003]
+    Teh, Yee Whye and Welling, Max and Osindero, Simon and Hinton, Geoffrey E.
+    "Energy-based models for sparse overcomplete representations."
+    Journal of Machine Learning Research, Num 4, December, pages 1235--1260.
+    2003
+
 .. [Tep2021]
     Alexander Teplukhin, Brian K. Kendrick, Susan M. Mniszewski, Yu Zhang,
     Ashutosh Kumar, Christian F.A. Negre, Petr M. Anisimov, Sergei Tretiak and
@@ -996,6 +1308,37 @@ Bibliography
     "Toward Robustness against Label Noise in Training Deep Discriminative
     Neural Networks." *arXiv:1706.00038*. 27 May 2017.
     https://arxiv.org/abs/1706.00038
+
+.. [Van2016]
+    Van Den Oord, A{\"a}ron and Kalchbrenner, Nal and Kavukcuoglu, Koray.
+    "Pixel recurrent neural networks."
+    International conference on machine learning
+    Pages 1747--1756
+    2016
+    arXiv:1601.06759
+    doi:10.48550/arXiv.1601.06759
+
+.. [Van2017]
+    Van Den Oord, Aaron and Vinyals, Oriol and others.
+    "Neural discrete representation learning."
+    NIPS'17: Proceedings of the 31st International Conference on Neural Information Processing Systems
+    Pages 6309 - 6318
+    04 December 2017
+
+.. [Vas2017]
+    Vaswani, Ashish and Shazeer, Noam and Parmar, Niki and Uszkoreit, Jakob and
+    Jones, Llion and Gomez, Aidan N and Kaiser, {\L}ukasz and Polosukhin, Illia.
+    "Attention is all you need."
+    NIPS'17: Proceedings of the 31st International Conference on Neural Information Processing Systems
+    Pages 6000 - 6010
+    04 December 2017
+
+.. [Vat2021]
+    Vats, Dootika and Knudson, Christina
+    "Revisiting the Gelman-Rubin Diagnostic."
+    Statist. Sci. 36 (4) 518 - 529
+    November 2021
+    https://doi.org/10.1214/20-STS812
 
 .. [Ven2015]
     Davide Venturelli, Dominic J.J. Marchand, and Galo Roj.
@@ -1029,6 +1372,13 @@ Bibliography
     on a 5,564-qubit quantum annealer." (2025) Nature Physics 21, 386.
     https://doi.org/10.1038/s41567-024-02765-w
 
+.. [Wai2008]
+    Wainwright, Martin J and Jordan, Michael I and others.
+    "Graphical Models, Exponential Families, and Variational Inference."
+    Found. Trends Mach. Learn. 1, 1-2, 1-305.
+    January 2008
+    https://doi.org/10.1561/2200000001
+
 .. [Wan2020]
     Wang, B., Hu, F., Yao, H. et al.
     "Prime factorization algorithm based on parameter optimization of
@@ -1049,6 +1399,20 @@ Bibliography
     "Satisfiability based set membership filters." Journal on Satisfiability,
     Boolean Modeling and Computation 8, 129 (2014).
     https://www.cs.uky.edu/~marek/papers.dir/11.dir/JSAT8_10_Weaver.pdf
+
+.. [Wie2022]
+    Wierichs, David and Izaac, Josh and Wang, Cody and Lin, Cedric Yen-Yu.
+    Quantum 6, 677
+    Verein zur F{\"o}rderung des Open Access Publizierens in den Quantenwissenschaften.
+    2022
+    https://doi.org/10.22331/q-2022-03-30-677
+
+.. [Wil1992]
+    Williams, Ronald J
+    "Simple statistical gradient-following algorithms for connectionist reinforcement learning."
+    Machine Learning, Volume 8, Issue 3-4, Pages 229 - 256
+    01 May 1992
+    https://doi.org/10.1007/BF00992696
 
 .. [Wil2019]
     D. Willsch, M. Willsch, H. De Raedt et al.,
@@ -1084,3 +1448,16 @@ Bibliography
     High Performance Computing. ISC High Performance 2020. Lecture Notes in
     Computer Science (LNCS), vol 12151. Springer, Cham.
     https://doi.org/10.1007/978-3-030-50743-5_10
+
+.. [Zha2017]
+    Zhao, Shengjia and Song, Jiaming and Ermon, Stefano.
+    "InfoVAE: Information maximizing variational autoencoders."
+    2017
+    arXiv preprint arXiv:1706.02262
+
+.. [Zha2025]
+    Zhang, Hao and Kamenev, Alex.
+    "Quantum sequel of neural network training."
+    Commun Phys 8, 478
+    2025
+    https://doi.org/10.1038/s42005-025-02384-8

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -575,7 +575,7 @@ section.
 Generative and Discriminative Modeling
 --------------------------------------
 
-*Generative* modeling is concerned with the modeling the joint distribution of
+*Generative* modeling is concerned with modeling the joint distribution of
 random variables :math:`X, Y`, whereas *discriminative* modeling is concerned
 with the conditional distribution of :math:`X \mid Y`.
 
@@ -588,7 +588,7 @@ both Boltzmann machines and quantum neural networks [Kak1995]_, [Chr1995]_.
 
 .. [#]
     Closely related to Boltzmann machines are the exponential family [Wai2008]_
-    Markov random fields [Dob1968]_, and Ising models [Isi1925]_.
+    Markov random fields [Dob1968]_ and Ising models [Isi1925]_.
 
 .. _boltzmann_machines_quantum_generalization:
 
@@ -642,7 +642,6 @@ and :math:`z_{e_i} = x_{e_{i_1}}x_{e_{i_2}}`,
 
 When only a subset of variables are observed, denoted :math:`v`, the remaining
 unobserved variables are referred to as *hidden units* :math:`h`.
-
 The marginal distribution of observed variables can be far more expressive due
 to the marginalization of hidden units; i.e.,
 
@@ -657,7 +656,6 @@ discussed in the :ref:`generative_discriminative_conclusion` section.
 
 Given a binary dataset, one can fit a Boltzmann machine to the model using, for
 example, maximum likelihood estimates [Cas2002]_.
-
 However, the maximum likelihood estimate for a Boltzmann machine is nontrivial
 to evaluate. The standard approach [Hin2002]_, [Ack1985]_ is to optimize the
 model using stochastic gradient descent [Boy2004]_.
@@ -711,10 +709,10 @@ In D-Wave's implementation, these Hamiltonians take the form:\ [#]_
                 \end{bmatrix} \\
         Z   & = \begin{bmatrix}
                     1 & 0 \\ 0 & -1
-                \end{bmatrix}.
+                \end{bmatrix},
     \end{align}
 
-The product :math:`\bigotimes` denotes the Kronecker product [Str2012]_.
+where the product :math:`\bigotimes` denotes the Kronecker product [Str2012]_.
 The probability measure is now defined by the diagonal elements of the density
 matrix,
 
@@ -725,7 +723,7 @@ matrix,
         \mathcal{Z} & = \Tr\left[\exp\{-H\}\right].
     \end{align}
 
-For intuition, consider a diagonal Hamiltonian---diagonal Hamiltonian
+To gain an intuitive understanding, consider a diagonal Hamiltonian---diagonal Hamiltonian
 (:math:`\gamma_i = 0` for all :math:`i`) corresponds to the classical definition of a
 Boltzmann machine. By construction of the Hamiltonian, the summation over
 :math:`Z_i` and :math:`Z_iZ_j` matrices result in a matrix whose diagonal
@@ -741,7 +739,7 @@ the log likelihood [Ami2018]_.
 
     The Hamiltonian is time-dependent but, motivated by ease of exposition, the
     dependence on time has been omitted here. For a more complete treatment,
-    see, for example, the :ref:`qpu_quantum_annealing_intro` section.
+    see the :ref:`qpu_quantum_annealing_intro` section.
 
 Quantum Boltzmann Machines: Applications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -858,7 +856,7 @@ Boltzmann machine during training.\ [#]_
 At inference, however, only variables associated with :math:`X` are fixed at
 their observed value and predictions are computed by sampling :math:`Y\mid X`.
 In practice, discriminative modeling with sparse graph-restricted Boltzmann
-machines poses a subtle variable-assignment problem to be discussed in the
+machines poses a subtle variable-assignment problem, which is discussed in the
 :ref:`generative_discriminative_conclusion` section.
 
 .. [#]
@@ -868,10 +866,10 @@ machines poses a subtle variable-assignment problem to be discussed in the
 Quantum Neural Networks
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Quantum neural networks [Kak1995]_, [Chr1995]_ are families of functions
+Quantum neural networks ([Kak1995]_, [Chr1995]_) are families of functions
 evaluated via parameterized quantum systems.\ [#]_
 That is, a quantum neural network, :math:`f_\theta`, parameterized by
-:math:`\theta` is defined as,
+:math:`\theta` is defined as
 
 .. math::
 
@@ -889,7 +887,6 @@ quantum observable.
 Essentially, a quantum neural network is a parameterized function whose outputs
 are expected values of the quantum system. A difficulty in applying quantum
 neural networks to real-world applications is in training.
-
 Evaluating or even approximating gradients of a loss function with respect to
 the network parameters is nontrivial due to the intractability of densities and
 expectations. Much of the literature on training quantum neural networks has
@@ -912,12 +909,12 @@ Consider an example Hamiltonian of the form,
 
 where :math:`Z_i` are as defined in the
 :ref:`boltzmann_machines_quantum_generalization` section, :math:`J_{i,j}, h_i`
-are scalar functions of the input data :math:`x`; that is
+are scalar functions of the input data :math:`x`; that is,
 :math:`h_i: \mathbb{R}^d \mapsto \mathbb{R}` and
-:math:`J_{i, j}:\mathbb{R}^d \mapsto \mathbb{R}`. Note, :math:`h_i` and
+:math:`J_{i, j}:\mathbb{R}^d \mapsto \mathbb{R}`. Note :math:`h_i` and
 :math:`J_{i, j}` include constant functions independent of :math:`x`.
 Equilibrium propagation approximates the gradients by introducing another
-Hamiltonian, a nudge Hamiltonian, defined as,
+Hamiltonian, a nudge Hamiltonian, defined as
 
 .. math::
 
@@ -928,7 +925,7 @@ Hamiltonian, a nudge Hamiltonian, defined as,
 where :math:`y \in \mathbb{R}^{d_2}` are the desired network outputs, and
 :math:`\tilde h_i` is similarly defined to :math:`h`,
 :math:`\tilde h_i: \mathbb{R}^d \mapsto \mathbb{R}`. The gradient is expressed
-as,
+as
 
 .. math::
 
@@ -959,8 +956,8 @@ annealers [Boo2019]_, [Boo2021]_ to implement a convolutional neural network
 A closely related approach is quantum reservoir computing [Kor2024]_.
 Informally but practically, quantum reservoir computing equates to evaluating an
 untrained quantum neural network, as an activation function, followed by a
-trained linear function. The difficulty in applying quantum reservoirs is the
-domain-expertise required in defining a base Hamiltonian and a mapping of inputs
+trained linear function. The difficulty in applying quantum reservoirs is that it
+requires domain-expertise to define a base Hamiltonian and a mapping of inputs
 to the base Hamiltonian.
 
 .. [#]
@@ -975,12 +972,12 @@ Opportunities and Limitations
 Boltzmann machines and quantum neural networks provide powerful frameworks for
 generative and discriminative modeling using annealing quantum computers.
 Naturally, these models can be readily inserted
-into---or substitute for---subcomponents of existing models: for example,
+into---or substitute for---subcomponents of existing models, such as
 linear layers, activation functions, and attention modules. Thus there is
 interest in identifying areas for which practical benefits can be realized with
 quantum annealing-based machine learning methods.
 
-This section considers three performance indicators in which a annealing quantum
+This section considers three performance indicators in which an annealing quantum
 computer has potential to improve upon classical baselines.
 
 1)  Runtime
@@ -989,7 +986,6 @@ computer has potential to improve upon classical baselines.
 
 First, a description of timing information of D-Wave's annealing quantum
 computers at a coarsened but practically relevant granularity.
-
 Quantum annealing protocols can operate in time spans as short as nanoseconds to
 as long as milliseconds. Once the protocol has run its course, reading out the
 classical states takes on the order of hundreds of microseconds. The bottleneck
@@ -1004,7 +1000,7 @@ is on the order of tens of milliseconds.
 A comprehensive breakdown of timing information is in the
 :ref:`qpu_operation_timing` section.
 
-To put this timing into context, consider both generative and discriminative
+To put this timing in context, consider both generative and discriminative
 modeling tasks.
 
 In a generative model setup where annealing quantum computers are utilized as
@@ -1049,7 +1045,7 @@ section.
 The two families of graphs are visualized in the :ref:`qpu_topologies` section.
 A key observation relevant to the discussion of expressivity is the locality of
 interactions. In both family of graphs, edges are locally connected in a
-two-dimensional plane; long range interactions do not exist. These locality
+two-dimensional plane and long-range interactions do not exist. These locality
 constraints motivate techniques for maximizing expressivity, which are discussed
 next.
 
@@ -1058,9 +1054,9 @@ Several approaches exist to increase model expressivity.
 1)  Minor embeddings [Cho2008]_: represent logical variables by chaining
     multiple physical qubits through strong pairwise interaction terms.
 2)  Hidden units: marginalize a distribution over its hidden units.
-3)  Optimize variable-to-qubit mappings.
+3)  Optimization of variable-to-qubit mappings.
 
-Minor embedding can increase connectivity and introduce long-range interactions,
+Minor embedding can increase connectivity and introduce long-range interactions
 but introduces its own challenges such as early freezeout and chain
 breakages.\ [#]_
 

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -572,6 +572,520 @@ section.
     "weak" predictors in such a way as to produce a more powerful, "strong"
     predictor.
 
+Generative and Discriminative Modeling
+--------------------------------------
+
+*Generative* modelling is concerned with the modeling the joint distribution of
+random variables :math:`X, Y`, whereas *discriminative* modeling is concerned
+with the conditional distribution of :math:`X \mid Y`.
+
+Generative modelling with annealing quantum computers is modeled by Boltzmann
+machines and quantum Boltzmann machines [Ami2018]_, [Ack1985]_---families of
+learnable probability models over binary data.\ [#]_
+
+Discriminative modelling with annealing quantum computers can be modelled using
+both Boltzmann machines and quantum neural networks [Kak1995]_, [Chr1995]_.
+
+.. [#]
+    Closely related to Boltzmann machines are the exponential family [Wai2008]_
+    Markov random fields [Dob1968]_, and Ising models [Isi1925]_.
+
+.. _boltzmann_machines_quantum_generalization:
+
+Boltzmann Machines and its Quantum Generalization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Boltzmann machines model high-dimensional binary data. A Boltzmann machine is
+defined by its probability mass function,
+
+.. math::
+
+    \begin{align}
+        P_\theta(x) &= \frac{1}{Z(\theta)}\exp\{\langle T(x) ,
+            \theta \rangle \} \\
+        Z(\theta) & = \sum_{s \in \{\pm 1\} ^n}\exp\{\langle T(s) ,
+            \theta \rangle \},
+    \end{align}
+
+where :math:`x \in \{\pm 1\}^n` for some dimension
+:math:`n`, :math:`\theta \in \mathbb{R}^{n+n(n-1)/2}` are the model parameters,
+and :math:`T: \{\pm 1\}^n \mapsto \{\pm 1\}^{n+n(n-1)/2}` is the sufficient
+statistic [Wai2008]_ of the model; i.e.,
+
+.. math::
+
+    \begin{equation}
+        T(x) = \begin{bmatrix}
+            x_1 & x_2 & \dots & x_n & x_1x_2 & x_1 x_3 & \dots & x_2 x_3 &
+            \dots & x_{n-1} x_n
+        \end{bmatrix}^\intercal.
+    \end{equation}
+
+More generally, given a graph :math:`G=(V, E)`, define a graph-restricted
+Boltzmann machine specified by :math:`G` to have sufficient statistics defined
+by,
+
+.. math::
+
+    \begin{align}
+        T(x) & =
+        \begin{bmatrix}
+            x_{v_1} & \dots & x_{n} & z_{e_1} & \dots & z_{e_m},
+        \end{bmatrix}^\intercal,
+    \end{align}
+
+where :math:`v_i \in V` for :math:`i \in \{1, \dots, \lvert V\rvert\}`,
+and :math:`z_{e_i} = x_{e_{i_1}}x_{e_{i_2}}`,
+:math:`e_i = (e_{i_1}, e_{i_2}) \in E` for
+:math:`i \in \{1, \dots, \lvert E \rvert \}`, and
+:math:`\theta \in \mathbb{R}^{\lvert V \rvert + \lvert E \rvert}`.
+
+When only a subset of variables are observed, denoted :math:`v`, the remaining
+unobserved variables are referred to as *hidden units* :math:`h`.
+
+The marginal distribution of observed variables can be far more expressive due
+to the marginalization of hidden units, i.e.,
+
+.. math::
+
+    \begin{align}
+        P_\theta^\text{m}(v) & = \sum_{h} P_\theta(x=(v, h)).
+    \end{align}
+
+The inclusion of hidden units can potentially introduce challenges to be
+discussed in the :ref:`generative_discriminative_conclusion` section.
+
+Given a binary dataset, one can fit a Boltzmann machine to the model using, for
+example, maximum likelihood estimates [Cas2002]_.
+
+However, the maximum likelihood estimate for a Boltzmann machine is nontrivial
+to evaluate. The standard approach [Hin2002]_, [Ack1985]_ is to optimize the
+model using stochastic gradient descent [Boy2004]_.
+
+The gradient of the log likelihood function itself is intractable:
+
+.. math::
+
+    \begin{align}
+        \nabla_\theta \log P_\theta(v) & = T(v) - \mathbb{E}\left[ T(X)\right].
+    \end{align}
+
+Its intractability stems from the expectation term, with respect to the model,
+which requires an evaluation of the partition function :math:`Z(\theta)`.
+
+This motivates the need for Monte Carlo algorithms [Rob2004]_; i.e., sample
+approximations of the expectation.
+
+Sampling from Boltzmann machines is notoriously difficult and is where the
+annealing quantum computer excels.
+
+The restricted Boltzmann machine [Hin2002]_, [Smo1986]_ is a special case of the
+graph-restricted Boltzmann machine in which the graph is a complete bipartite
+graph. Furthermore, partial observations are restricted to be on one and only
+one partite set of the graph. These modelling constraints were motivated by the
+need for an efficient training algorithm [Hin2002]_, [Hin2010]_.
+
+Quantum Boltzmann machines offer a generalization of Boltzmann machines and are
+defined by Hamiltonians.
+
+In practice today (2026, the time of writing), at D-Wave the annealing quantum
+computer is utilized as an approximate sampler of quantum Boltzmann machines.
+Thus the following introductory definition only serves to satisfy one's
+curiosity. Refer to [Ami2018]_ for a complete treatment.
+
+In D-Wave's implementation, these Hamiltonians take the form:\ [#]_
+
+.. math::
+
+    \begin{align}
+        H   & = \sum_{i \in V} h_i Z_i + \sum_{(i, j)\in E} J_{i,j} Z_i Z_j +
+                \sum_{i\in V} \gamma_i X_i \\
+        Z_i & = \left( \bigotimes_{j=1}^{j=i-1} I_2 \right)
+                Z \left( \bigotimes_{j=i+1}^{j=\lvert V \rvert} I_2 \right) \\
+        X_i & = \left( \bigotimes_{j=1}^{j=i-1} I_2 \right)
+                X \left( \bigotimes_{j=i+1}^{j=\lvert V \rvert} I_2 \right) \\
+        I_2 & = \begin{bmatrix}
+                    1 & 0 \\ 0 & 1
+                \end{bmatrix} \\
+        X   & = \begin{bmatrix}
+                    0 & 1 \\ -1 & 0
+                \end{bmatrix} \\
+        Z   & = \begin{bmatrix}
+                    1 & 0 \\ 0 & -1
+                \end{bmatrix}.
+    \end{align}
+
+The product :math:`\bigotimes` denotes the Kronecker product [Str2012]_.
+The probability measure is now defined by the diagonal elements of the density
+matrix,
+
+.. math::
+
+    \begin{align}
+        \rho & = \frac{1}{\mathcal{Z}}\exp\{-H\} \\
+        \mathcal{Z} & = \Tr\left[\exp\{-H\}\right].
+    \end{align}
+
+For intuition, consider a diagonal Hamiltonian---diagonal Hamiltonian
+(:math:`\gamma_i = 0` for all :math:`$i`) corresponds to the classical definition of a
+Boltzmann machine. By construction of the Hamiltonian, the summation over
+:math:`Z_i` and :math:`Z_iZ_j` matrices result in a matrix whose diagonal
+entries correspond to each of the :math:`2^{\lvert V\rvert}` binary strings'
+probability (when normalized).
+When qubits are measured in the :math:`z`-basis, or with respect to each
+:math:`Z_i`, binary strings are observed with their corresponding probabilities.
+The quantum Boltzmann machine can be trained using the same expressions or
+quantities as in classical Boltzmann machines, albeit based on a lower bound of
+the log likelihood [Ami2018]_.
+
+.. [#]
+
+    The Hamiltonian is time-dependent but, motivated by ease of exposition, the
+    dependence on time has been omitted here. For a more complete treatment,
+    see, for example, the :ref:`qpu_quantum_annealing_intro` section.
+
+Quantum Boltzmann Machines: Applications
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Applying arbitrary graph-restricted Boltzmann machines to real-world
+applications raises at least two challenges.
+
+1)  Data are seldom natively binary. For example, image data are continuous and
+    text data are categorical.
+2)  Correlations are not guaranteed to be local and quadratic even when data are
+    binary, thereby limiting the expressivity and goodness-of-fit of
+    graph-restricted Boltzmann machines.
+
+Identifying a mapping of input variables to model variables is at least as
+difficult as the quadratic assignment problem [Law1963]_---an NP-hard problem.
+The problem can be formulated as maximizing the likelihood function over both
+mappings and parameters.
+
+Both challenges can be addressed via several approaches.
+One solution is to leverage variants of (variational) autoencoders [Sch2015]_,
+[Bal1987]_, [Kin2013]_, for example, [Rol2016]_, [Li2016]_, [Zha2017]_,
+[Van2017]_, [Jan2016]_, [Kho2018]_.
+The idea underpinning these approaches is to enforce a discrete-latent-space
+constraint in the model.
+
+Defining variational autoencoders [Kin2013]_ with discrete latent variables is
+not a problem because the reparameterization trick [Kin2013]_ is not limited to
+real-valued random variables [Rol2016]_.
+However, a problem arises in training such a discrete model via gradient
+descent: gradients are zero for discrete random variables. [Rol2016]_ addresses
+this training problem by augmenting binary latent variables with real-valued
+random variables. The auxiliary variables are equipped with distributions
+conditioned on the binary variables, resulting in nonzero gradients in
+backpropagation [Sch2015]_.
+
+For example, consider the random variable :math:`Z \mid B` where :math:`B` is a
+Bernoulli random variable and :math:`Z \mid B = 0` is :math:`0`, and
+:math:`Z \mid B = 1 \sim \text{Exponential}(1)`.
+
+Using the inverse conditional distribution function (CDF) sampling method
+[Rob2004]_, you have,
+
+.. math::
+
+    \begin{align}
+        u & \sim \text{Uniform}(0, 1) \\
+        x & \in [0, 1] \\
+        f(x, u) & = \begin{cases}
+                        0  & u > x \\
+                        \log \left[ \frac{u+x-1}{x}(e-1) +1	\right] & u \leq x
+                    \end{cases},
+    \end{align}
+
+where :math:`u` is the *noise variable*, :math:`x` is the encoded data input,
+and the second case for :math:`f` comes from the inverse CDF of the exponential
+distribution. Because :math:`f` is differentiable with nonzero gradients, one
+can meaningfully backpropagate through the discretization layer.
+
+Another approach to modelling data with binary random variables is to use
+approximations proposed by [Jan2016]_, [Mad2016]_. The approach is based on a
+limiting argument with annealed Gumbel distributions combined with a
+straight-through estimator [Ben2013]_,
+
+.. math::
+
+    \begin{align}
+        z_i & = \frac{\exp (\frac{\log (\pi_i ) + g_i}{\tau})}
+        {\sum_j \exp (\frac{\log (\pi_j ) + g_j}{\tau})} \\
+        z & = \begin{bmatrix}
+                z_1 & z_2 & \dots & z_K
+              \end{bmatrix} \\
+        i & \in \{1, \dots, K\},
+    \end{align}
+
+where :math:`K` represents the number of discrete values (:math:`K=2` for
+binary) and :math:`\tau` is an annealing parameter. When :math:`\tau \to 0`,
+:math:`z` becomes a one-hot vector; i.e., :math:`z_i = 1` for some index
+:math:`i` and :math:`0` for all other indices not equal to :math:`i`.
+
+In a recent molecular-design application, [Kun2026]_ leveraged ideas from the
+neural hash function of [Eri2015]_ to discretize data. The binarization strategy
+applied in [Eri2015]_ penalizes the encoding network, during training, when
+latent variables deviate from :math:`\pm 1`. That is, the following loss
+function is added as a regularizer to the neural network training objective:
+
+.. math::
+
+    \begin{equation}
+        L_\text{quant}(z) = \lvert \lvert z - \text{sign}(z)\rvert \rvert ^2.
+    \end{equation}
+
+Finally, *REINFORCE* [Wil1992]_, [Gly1990]_ can also be used to backpropagate
+gradients through discretization layers,
+
+.. math::
+
+    \begin{equation}
+        \nabla_x \mathbb{E}_Z[f(Z)] = \mathbb{E}_Z[f(Z)\nabla_x \log p_x(Z)].
+    \end{equation}
+
+A drawback of REINFORCE is that the estimator is effectively computed by
+expressions akin to finite differences, resulting in high variance. Bespoke
+variance-reduction techniques [Rob2004]_ are often required to stabilize the
+estimator. See [Jan2016]_ for a summary of relevant variance-reduction
+techniques based on control variates.
+
+Boltzmann machines can also be used as discriminative models or, equivalently,
+used for modelling conditional distributions :math:`Y \mid X`. See [Cal2019]_
+for an applied example using annealing quantum computers. Training of Boltzmann
+machines for discriminative tasks is no different from training generative
+models. Variables :math:`X` and :math:`Y` are both assigned to variables of a
+Boltzmann machine during training.\ [#]_
+
+At inference, however, only variables associated with :math:`X` are fixed at
+their observed value and predictions are computed by sampling :math:`Y\mid X`.
+In practice, discriminative modelling with sparse graph-restricted Boltzmann
+machines poses a subtle variable-assignment problem to be discussed in the
+:ref:`generative_discriminative_conclusion` section.
+
+.. [#]
+    This assignment or mapping of variables can be performed via an encoder or
+    by manual assignment.
+
+Quantum Neural Networks
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Quantum neural networks [Kak1995]_, [Chr1995]_ are families of functions
+evaluated via parameterized quantum systems.\ [#]_
+That is, a quantum neural network, :math:`f_\theta`, parameterized by
+:math:`\theta` is defined as,
+
+.. math::
+
+    \begin{equation}
+        f_\theta(x) = \langle \psi_0 \lvert U^\dagger_\theta(x) \hat F
+            U_\theta(x) \rvert \psi_0 \rangle,
+    \end{equation}
+
+where :math:`x \in \mathbb{R}^d` represents input data, :math:`U_\theta`
+represents a unitary transformation, :math:`U_\theta^\dagger` its conjugate
+transpose, :math:`\lvert \psi_0 \rangle` is an initial state of the system,
+:math:`\langle \psi_0 \rvert` its conjugate transpose, and :math:`\hat F` is a
+quantum observable.
+
+Essentially, a quantum neural network is a parameterized function whose outputs
+are expected values of the quantum system. A difficulty in applying quantum
+neural networks to real-world applications is in training.
+
+Evaluating or even approximating gradients of a loss function with respect to
+the network parameters is nontrivial due to the intractability of densities and
+expectations. Much of the literature on training quantum neural networks has
+been dedicated to gate-model systems, using, for example, the parameter-shift
+rule and its generalizations [Mit2018]_, [Wie2022]_.
+
+A more relevant approach to training quantum annealing-based neural networks is
+via equilibrium propagation [Sce2017]_, a gradient-estimation technique
+originally introduced in the context of training energy-based models [teh2003]_.
+Generalizations to quantum equilibrium propagation have been proposed in
+[Mas2025]_, [Sce2024]_. The parameter update rule can be described as follows.
+
+Consider an example Hamiltonian of the form,
+
+.. math::
+
+    \begin{equation}
+        H(x) = \sum_{i, j} J_{i,j}(x) Z_iZ_j + \sum_i h_i(x) Z_i,
+    \end{equation}
+
+where :math:`Z_i` are as defined in the
+:ref:`boltzmann_machines_quantum_generalization` section, :math:`J_{i,j}, h_i`
+are scalar functions of the input data :math:`x`; that is
+:math:`h_i: \mathbb{R}^d \mapsto \mathbb{R}` and
+:math:`J_{i, j}:\mathbb{R}^d \mapsto \mathbb{R}`. Note, :math:`h_i` and
+:math:`J_{i, j}` include constant functions independent of :math:`x`.
+Equilibrium propagation approximates the gradients by introducing another
+Hamiltonian, a nudge Hamiltonian, defined as,
+
+.. math::
+
+    \begin{equation}
+        H_\text{nudge}(x, y) = H(x) - \sum_i \tilde h_i(y) Z_i,
+    \end{equation}
+
+where :math:`y \in \mathbb{R}^{d_2}` are the desired network outputs, and
+:math:`\tilde h_i` is similarly defined to :math:`h`,
+:math:`\tilde h_i: \mathbb{R}^d \mapsto \mathbb{R}`. The gradient is expressed
+as,
+
+.. math::
+
+    \begin{equation}
+        \nabla_\theta C(\theta, (x, y)) = \mathbb{E}_S[T(S)] -
+        \mathbb{E}_{S'}[T(S')],
+    \end{equation}
+
+where :math:`S, S'` are spin-valued random vectors with distribution prescribed
+by :math:`H(x), H_\text{nudge}(x, y)` respectively, :math:`\theta = (h, J)` (as
+defined in the :ref:`boltzmann_machines_quantum_generalization` section),
+:math:`T` is the sufficient statistic of :math:`H` (as defined in the
+:ref:`boltzmann_machines_quantum_generalization` section), and
+:math:`C: \mathbb{R}^{|V| + |E|} \times \mathbb{R}^d \times \mathbb{R}^{d_2} \mapsto \mathbb{R}`
+is a differentiable cost function (with respect to the first argument).
+The gradient, expressed as a difference of expectations, can be readily
+estimated by sampling from a quantum computer.
+
+An inefficiency of the approach is the need to sample from two separate
+distributions for one gradient computation.
+
+The applicability of quantum annealing-based neural networks has been
+demonstrated in MNIST [Den2012]_ image classification tasks [Zha2025]_,
+[Lay2024]_. Notably, [Lay2024]_ exploited the hardware topology of quantum
+annealers [Boo2019]_ ,[Boo2021]_ to implement a convolutional neural network
+[Fuk1979]_, [Sch2015]_.
+
+A closely related approach is quantum reservoir computing [Kor2024]_.
+Informally but practically, quantum reservoir computing equates to evaluating an
+untrained quantum neural network, as an activation function, followed by a
+trained linear function. The difficulty in applying quantum reservoirs is the
+domain-expertise required in defining a base Hamiltonian and a mapping of inputs
+to the base Hamiltonian.
+
+.. [#]
+    "Quantum neural networks" are often used synonymously with "variational quantum circuits" or
+    "parameterized quantum circuits".
+
+.. _generative_discriminative_conclusion:
+
+Opportunities and Limitations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Boltzmann machines and quantum neural networks provide powerful frameworks for
+generative and discriminative modelling using annealing quantum computers.
+Naturally, these models can be readily inserted
+into---or substitute for---subcomponents of existing models: for example,
+linear layers, activation functions, and attention modules. Thus there is
+interest in identifying areas for which practical benefits can be realized with
+quantum annealing-based machine learning methods.
+
+This section considers three performance indicators in which a annealing quantum
+computer has potential to improve upon classical baselines.
+
+1)  Runtime
+2)  Model complexity
+3)  Power consumption
+
+First, a description of timing information of D-Wave's annealing quantum
+computers at a coarsened but practically relevant granularity.
+
+Quantum annealing protocols can operate in time spans as short as nanoseconds to
+as long as milliseconds. Once the protocol has run its course, reading out the
+classical states takes on the order of hundreds of microseconds. The bottleneck
+in this protocol is in programming the Hamiltonian to the annealing quantum
+computer, which is on the order of tens of milliseconds.
+
+Because D-Wave's annealing quantum computers are accessed via |cloud_tm|_, a
+quantum cloud platform, there may be additional network latencies in the order
+of hundreds of milliseconds. In principle, communication latency can be
+mitigated and programming time optimized such that the effective processing time
+is on the order of tens of milliseconds.
+A comprehensive breakdown of timing information is in the
+:ref:`qpu_operation_timing` section.
+
+To put this timing into context, consider both generative and discriminative
+modelling tasks.
+
+In a generative model setup where annealing quantum computers are utilized as
+Boltzmann machine samplers, the natural comparators are Monte Carlo samplers
+such as the Metropolis algorithm [Met1953]_ [Rob2004]_. Metropolis algorithm
+sampling times can range from hundreds of milliseconds to seconds when sampling
+from the same Boltzmann machine as the annealing quantum computer for an
+equivalent effective sample size [Vat2021]_.
+
+For complex models, more sophisticated and compute-intensive methods such as
+parallel tempering [Gey1991]_ and annealed importance sampling [nea2001]_ are
+required.
+
+Other alternatives include autoregressive models [Van2016]_, [Vas2017]_,
+[Gu2024]_, which are model-dependent but generally slow due to repeated neural
+network evaluations.
+
+In a discriminative model where an annealing quantum computer is utilized as a
+quantum Boltzmann machine or a quantum neural network, it is sensible to
+consider classical neural network module runtimes for reference. For example, a
+self-attention [Vas2017]_ module requires approximately half a millisecond
+to evaluate a sequence of length :math:`1024` by :math:`1024` dimensions using a
+modern graphical processing unit (GPU; NVIDIA L4).\ [#]_
+
+Flash attention [Dao2022]_---a hardware-optimized attention module---reported
+runtimes of :math:`1`\--\ :math:`10`\ s of milliseconds (including
+backpropagation) for inputs of length ranging from :math:`1000`\ s to
+:math:`8000`\ s. If, however, one insists on sampling from the quantum neural
+network via, say, classical simulations and approximations, then annealing
+quantum computers are likely to perform favorably.
+
+While restricted Boltzmann machines are universal approximators [Ler2008]_,
+[Mon2020]_, D-Wave's annealing quantum computers are implemented with sparse
+connectivity and are thus limited in their expressivity.
+The |dwave_5kq_tm| system and |adv2_tm| system's topologies are defined by the
+:term:`Pegasus` and :term:`Zephyr` family of graphs respectively [Boo2019]_,
+[Boo2021]_. Each vertex represents a qubit, and each edge represents a coupler.
+In other words, these graphs are used to define graph-restricted Boltzmann
+machines described in the :ref:`boltzmann_machines_quantum_generalization`
+section.
+
+The two families of graphs are visualized in the :ref:`qpu_topologies` section.
+A key observation relevant to the discussion of expressivity is the locality of
+interactions. In both family of graphs, edges are locally connected in a
+two-dimensional plane; long range interactions do not exist. These locality
+constraints motivate techniques for maximizing expressivity, which are discussed
+next.
+
+Several approaches exist to increase model expressivity.
+
+1)  Minor embeddings [Cho2008]_: represent logical variables by chaining
+    multiple physical qubits through strong pairwise interaction terms.
+2)  Hidden units: marginalize a distribution over its hidden units.
+3)  Optimize variable-to-qubit mappings.
+
+Minor embedding can increase connectivity and introduce long-range interactions,
+but introduces its own challenges such as early freezeout and chain
+breakages.\ [#]_
+
+Hidden units can be interpreted similarly to embeddings where the embeddings are
+learned implicitly. However, this also introduces complexity to training
+methods. For example, when using tractable closed-form expressions for
+marginalization, the effective inverse temperature must be estimated [Ray2016]_.
+When using sample approximations for marginalization, multiple invocations of
+the annealing quantum computer will be required.
+
+The competitive runtime and model expressivity is further complemented by a
+constant power consumption [Dwave8]_ independent of model complexity.
+This constant power consumption is because almost all power drawn from D-Wave's
+systems goes toward cryogenic refrigeration; the bulk of the computation is
+analog. This suggests model complexity can be further enhanced through a liberal
+composition of quantum Boltzmann machines and quantum neural networks.
+
+.. [#]
+    The implementation is a compiled PyTorch module [Pas2019]_.
+
+.. [#]
+    See the :ref:`qpu_qa_freezeout` and
+    :ref:`chain breaks <qpu_embedding_intro_chains>` sections.
+
 Code Examples
 -------------
 

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -592,8 +592,8 @@ both Boltzmann machines and quantum neural networks [Kak1995]_, [Chr1995]_.
 
 .. _boltzmann_machines_quantum_generalization:
 
-Boltzmann Machines and its Quantum Generalization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Boltzmann Machines: Quantum Generalization
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Boltzmann machines model high-dimensional binary data. A Boltzmann machine is
 defined by its probability mass function,
@@ -644,7 +644,7 @@ When only a subset of variables are observed, denoted :math:`v`, the remaining
 unobserved variables are referred to as *hidden units* :math:`h`.
 
 The marginal distribution of observed variables can be far more expressive due
-to the marginalization of hidden units, i.e.,
+to the marginalization of hidden units; i.e.,
 
 .. math::
 
@@ -672,7 +672,6 @@ The gradient of the log likelihood function itself is intractable:
 
 Its intractability stems from the expectation term, with respect to the model,
 which requires an evaluation of the partition function :math:`Z(\theta)`.
-
 This motivates the need for Monte Carlo algorithms [Rob2004]_; i.e., sample
 approximations of the expectation.
 
@@ -691,7 +690,7 @@ defined by Hamiltonians.
 In practice today (2026, the time of writing), at D-Wave the annealing quantum
 computer is utilized as an approximate sampler of quantum Boltzmann machines.
 Thus the following introductory definition only serves to satisfy one's
-curiosity. Refer to [Ami2018]_ for a complete treatment.
+curiosity: Refer to [Ami2018]_ for a complete treatment.
 
 In D-Wave's implementation, these Hamiltonians take the form:\ [#]_
 
@@ -727,7 +726,7 @@ matrix,
     \end{align}
 
 For intuition, consider a diagonal Hamiltonian---diagonal Hamiltonian
-(:math:`\gamma_i = 0` for all :math:`$i`) corresponds to the classical definition of a
+(:math:`\gamma_i = 0` for all :math:`i`) corresponds to the classical definition of a
 Boltzmann machine. By construction of the Hamiltonian, the summation over
 :math:`Z_i` and :math:`Z_iZ_j` matrices result in a matrix whose diagonal
 entries correspond to each of the :math:`2^{\lvert V\rvert}` binary strings'
@@ -899,7 +898,7 @@ rule and its generalizations [Mit2018]_, [Wie2022]_.
 
 A more relevant approach to training quantum annealing-based neural networks is
 via equilibrium propagation [Sce2017]_, a gradient-estimation technique
-originally introduced in the context of training energy-based models [teh2003]_.
+originally introduced in the context of training energy-based models [Teh2003]_.
 Generalizations to quantum equilibrium propagation have been proposed in
 [Mas2025]_, [Sce2024]_. The parameter update rule can be described as follows.
 
@@ -942,7 +941,7 @@ where :math:`S, S'` are spin-valued random vectors with distribution prescribed
 by :math:`H(x), H_\text{nudge}(x, y)` respectively, :math:`\theta = (h, J)` (as
 defined in the :ref:`boltzmann_machines_quantum_generalization` section),
 :math:`T` is the sufficient statistic of :math:`H` (as defined in the
-:ref:`boltzmann_machines_quantum_generalization` section), and
+same section), and
 :math:`C: \mathbb{R}^{|V| + |E|} \times \mathbb{R}^d \times \mathbb{R}^{d_2} \mapsto \mathbb{R}`
 is a differentiable cost function (with respect to the first argument).
 The gradient, expressed as a difference of expectations, can be readily
@@ -954,7 +953,7 @@ distributions for one gradient computation.
 The applicability of quantum annealing-based neural networks has been
 demonstrated in MNIST [Den2012]_ image classification tasks [Zha2025]_,
 [Lay2024]_. Notably, [Lay2024]_ exploited the hardware topology of quantum
-annealers [Boo2019]_ ,[Boo2021]_ to implement a convolutional neural network
+annealers [Boo2019]_, [Boo2021]_ to implement a convolutional neural network
 [Fuk1979]_, [Sch2015]_.
 
 A closely related approach is quantum reservoir computing [Kor2024]_.
@@ -1016,7 +1015,7 @@ from the same Boltzmann machine as the annealing quantum computer for an
 equivalent effective sample size [Vat2021]_.
 
 For complex models, more sophisticated and compute-intensive methods such as
-parallel tempering [Gey1991]_ and annealed importance sampling [nea2001]_ are
+parallel tempering [Gey1991]_ and annealed importance sampling [Nea2001]_ are
 required.
 
 Other alternatives include autoregressive models [Van2016]_, [Vas2017]_,

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -581,7 +581,7 @@ modeling is concerned with modeling the joint distribution of random variables
 `discriminative <https://en.wikipedia.org/wiki/Discriminative_model>`_
 modeling is concerned with the conditional distribution of :math:`X \mid Y`.
 
-Generative modeling with annealing quantum computers is modeled by Boltzmann
+Generative modeling with annealing quantum computers can be modeled by Boltzmann
 machines and quantum Boltzmann machines [Ami2018]_, [Ack1985]_---families of
 learnable probability models over binary data.\ [#]_
 

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -575,15 +575,15 @@ section.
 Generative and Discriminative Modeling
 --------------------------------------
 
-*Generative* modelling is concerned with the modeling the joint distribution of
+*Generative* modeling is concerned with the modeling the joint distribution of
 random variables :math:`X, Y`, whereas *discriminative* modeling is concerned
 with the conditional distribution of :math:`X \mid Y`.
 
-Generative modelling with annealing quantum computers is modeled by Boltzmann
+Generative modeling with annealing quantum computers is modeled by Boltzmann
 machines and quantum Boltzmann machines [Ami2018]_, [Ack1985]_---families of
 learnable probability models over binary data.\ [#]_
 
-Discriminative modelling with annealing quantum computers can be modelled using
+Discriminative modeling with annealing quantum computers can be modeled using
 both Boltzmann machines and quantum neural networks [Kak1995]_, [Chr1995]_.
 
 .. [#]
@@ -682,7 +682,7 @@ annealing quantum computer excels.
 The restricted Boltzmann machine [Hin2002]_, [Smo1986]_ is a special case of the
 graph-restricted Boltzmann machine in which the graph is a complete bipartite
 graph. Furthermore, partial observations are restricted to be on one and only
-one partite set of the graph. These modelling constraints were motivated by the
+one partite set of the graph. These modeling constraints were motivated by the
 need for an efficient training algorithm [Hin2002]_, [Hin2010]_.
 
 Quantum Boltzmann machines offer a generalization of Boltzmann machines and are
@@ -801,7 +801,7 @@ and the second case for :math:`f` comes from the inverse CDF of the exponential
 distribution. Because :math:`f` is differentiable with nonzero gradients, one
 can meaningfully backpropagate through the discretization layer.
 
-Another approach to modelling data with binary random variables is to use
+Another approach to modeling data with binary random variables is to use
 approximations proposed by [Jan2016]_, [Mad2016]_. The approach is based on a
 limiting argument with annealed Gumbel distributions combined with a
 straight-through estimator [Ben2013]_,
@@ -850,7 +850,7 @@ estimator. See [Jan2016]_ for a summary of relevant variance-reduction
 techniques based on control variates.
 
 Boltzmann machines can also be used as discriminative models or, equivalently,
-used for modelling conditional distributions :math:`Y \mid X`. See [Cal2019]_
+used for modeling conditional distributions :math:`Y \mid X`. See [Cal2019]_
 for an applied example using annealing quantum computers. Training of Boltzmann
 machines for discriminative tasks is no different from training generative
 models. Variables :math:`X` and :math:`Y` are both assigned to variables of a
@@ -858,7 +858,7 @@ Boltzmann machine during training.\ [#]_
 
 At inference, however, only variables associated with :math:`X` are fixed at
 their observed value and predictions are computed by sampling :math:`Y\mid X`.
-In practice, discriminative modelling with sparse graph-restricted Boltzmann
+In practice, discriminative modeling with sparse graph-restricted Boltzmann
 machines poses a subtle variable-assignment problem to be discussed in the
 :ref:`generative_discriminative_conclusion` section.
 
@@ -974,7 +974,7 @@ Opportunities and Limitations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Boltzmann machines and quantum neural networks provide powerful frameworks for
-generative and discriminative modelling using annealing quantum computers.
+generative and discriminative modeling using annealing quantum computers.
 Naturally, these models can be readily inserted
 into---or substitute for---subcomponents of existing models: for example,
 linear layers, activation functions, and attention modules. Thus there is
@@ -1006,7 +1006,7 @@ A comprehensive breakdown of timing information is in the
 :ref:`qpu_operation_timing` section.
 
 To put this timing into context, consider both generative and discriminative
-modelling tasks.
+modeling tasks.
 
 In a generative model setup where annealing quantum computers are utilized as
 Boltzmann machine samplers, the natural comparators are Monte Carlo samplers

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -575,9 +575,11 @@ section.
 Generative and Discriminative Modeling
 --------------------------------------
 
-*Generative* modeling is concerned with modeling the joint distribution of
-random variables :math:`X, Y`, whereas *discriminative* modeling is concerned
-with the conditional distribution of :math:`X \mid Y`.
+`Generative <https://en.wikipedia.org/wiki/Discriminative_model#Contrast_with_generative_model>`_
+modeling is concerned with modeling the joint distribution of random variables
+:math:`X, Y`, whereas
+`discriminative <https://en.wikipedia.org/wiki/Discriminative_model>`_
+modeling is concerned with the conditional distribution of :math:`X \mid Y`.
 
 Generative modeling with annealing quantum computers is modeled by Boltzmann
 machines and quantum Boltzmann machines [Ami2018]_, [Ack1985]_---families of
@@ -587,8 +589,11 @@ Discriminative modeling with annealing quantum computers can be modeled using
 both Boltzmann machines and quantum neural networks [Kak1995]_, [Chr1995]_.
 
 .. [#]
-    Closely related to Boltzmann machines are the exponential family [Wai2008]_
-    Markov random fields [Dob1968]_ and Ising models [Isi1925]_.
+    Closely related to Boltzmann machines are the
+    `exponential family <https://en.wikipedia.org/wiki/Exponential_family>`_
+    [Wai2008]_,
+    `Markov random fields <https://en.wikipedia.org/wiki/Markov_random_field>`_
+    [Dob1968]_, and :term:`Ising` models [Isi1925]_.
 
 .. _boltzmann_machines_quantum_generalization:
 
@@ -609,8 +614,9 @@ defined by its probability mass function,
 
 where :math:`x \in \{\pm 1\}^n` for some dimension
 :math:`n`, :math:`\theta \in \mathbb{R}^{n+n(n-1)/2}` are the model parameters,
-and :math:`T: \{\pm 1\}^n \mapsto \{\pm 1\}^{n+n(n-1)/2}` is the sufficient
-statistic [Wai2008]_ of the model; i.e.,
+and :math:`T: \{\pm 1\}^n \mapsto \{\pm 1\}^{n+n(n-1)/2}` is the
+`sufficient statistic <https://en.wikipedia.org/wiki/Sufficient_statistic>`_
+[Wai2008]_ of the model; i.e.,
 
 .. math::
 
@@ -655,10 +661,13 @@ The inclusion of hidden units can potentially introduce challenges to be
 discussed in the :ref:`generative_discriminative_conclusion` section.
 
 Given a binary dataset, one can fit a Boltzmann machine to the model using, for
-example, maximum likelihood estimates [Cas2002]_.
-However, the maximum likelihood estimate for a Boltzmann machine is nontrivial
-to evaluate. The standard approach [Hin2002]_, [Ack1985]_ is to optimize the
-model using stochastic gradient descent [Boy2004]_.
+example,
+`maximum likelihood <https://en.wikipedia.org/wiki/Maximum_likelihood_estimation>`_
+estimates [Cas2002]_. However, the maximum likelihood estimate for a Boltzmann
+machine is nontrivial to evaluate. The standard approach [Hin2002]_, [Ack1985]_
+is to optimize the model using
+`stochastic gradient descent <https://en.wikipedia.org/wiki/Stochastic_gradient_descent>`_
+[Boy2004]_.
 
 The gradient of the log likelihood function itself is intractable:
 
@@ -684,10 +693,6 @@ need for an efficient training algorithm [Hin2002]_, [Hin2010]_.
 
 Quantum Boltzmann machines offer a generalization of Boltzmann machines and are
 defined by Hamiltonians.
-
-In practice at D-Wave in 2026, the annealing quantum computer is used as an
-approximate sampler of quantum Boltzmann machines, as described briefly here and
-in detail in [Ami2018]_.
 
 In D-Wave's implementation, these Hamiltonians take the form:\ [#]_
 
@@ -752,9 +757,10 @@ applications raises at least two challenges.
     graph-restricted Boltzmann machines.
 
 Identifying a mapping of input variables to model variables is at least as
-difficult as the quadratic assignment problem [Law1963]_---an NP-hard problem.
-The problem can be formulated as maximizing the likelihood function over both
-mappings and parameters.
+difficult as the
+`quadratic assignment problem <https://en.wikipedia.org/wiki/Quadratic_assignment_problem>`_
+[Law1963]_---an NP-hard problem. The problem can be formulated as maximizing the
+likelihood function over both mappings and parameters.
 
 Both challenges can be addressed via several approaches.
 One solution is to leverage variants of (variational) autoencoders [Sch2015]_,
@@ -792,9 +798,11 @@ Using the inverse conditional distribution function (CDF) sampling method
     \end{align}
 
 where :math:`u` is the *noise variable*, :math:`x` is the encoded data input,
-and the second case for :math:`f` comes from the inverse CDF of the exponential
-distribution. Because :math:`f` is differentiable with nonzero gradients, one
-can meaningfully backpropagate through the discretization layer.
+and the second case for :math:`f` comes from the
+`inverse CDF <https://en.wikipedia.org/wiki/Inverse_transform_sampling>`_
+of the exponential distribution. Because :math:`f` is differentiable with
+nonzero gradients, one can meaningfully backpropagate through the discretization
+layer.
 
 Another approach to modeling data with binary random variables is to use
 approximations proposed by [Jan2016]_, [Mad2016]_. The approach is based on a
@@ -840,9 +848,9 @@ gradients through discretization layers,
 
 A drawback of REINFORCE is that the estimator is effectively computed by
 expressions akin to finite differences, resulting in high variance. Bespoke
-variance-reduction techniques [Rob2004]_ are often required to stabilize the
-estimator. See [Jan2016]_ for a summary of relevant variance-reduction
-techniques based on control variates.
+`variance-reduction techniques <https://en.wikipedia.org/wiki/Variance_reduction>`_
+[Rob2004]_ are often required to stabilize the estimator. See [Jan2016]_ for a
+summary of relevant variance-reduction techniques based on control variates.
 
 Boltzmann machines can also be used as discriminative models or, equivalently,
 used for modeling conditional distributions :math:`Y \mid X`. See [Cal2019]_
@@ -864,10 +872,10 @@ machines poses a subtle variable-assignment problem, which is discussed in the
 Quantum Neural Networks
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Quantum neural networks ([Kak1995]_, [Chr1995]_) are families of functions
-evaluated via parameterized quantum systems.\ [#]_
-That is, a quantum neural network, :math:`f_\theta`, parameterized by
-:math:`\theta` is defined as
+`Quantum neural networks <https://en.wikipedia.org/wiki/Quantum_neural_network>`_
+([Kak1995]_, [Chr1995]_) are families of functions evaluated via parameterized
+quantum systems.\ [#]_ That is, a quantum neural network, :math:`f_\theta`,
+parameterized by :math:`\theta` is defined as
 
 .. math::
 
@@ -935,20 +943,19 @@ as
 where :math:`S, S'` are spin-valued random vectors with distribution prescribed
 by :math:`H(x), H_\text{nudge}(x, y)` respectively, :math:`\theta = (h, J)` (as
 defined in the :ref:`boltzmann_machines_quantum_generalization` section),
-:math:`T` is the sufficient statistic of :math:`H` (as defined in the
-same section), and
+:math:`T` is the
+`sufficient statistic <https://en.wikipedia.org/wiki/Sufficient_statistic>`_ of
+:math:`H` (as defined in the same section), and
 :math:`C: \mathbb{R}^{|V| + |E|} \times \mathbb{R}^d \times \mathbb{R}^{d_2} \mapsto \mathbb{R}`
 is a differentiable cost function (with respect to the first argument).
 The gradient, expressed as a difference of expectations, can be readily
 estimated by sampling from a quantum computer.
 
-An inefficiency of the approach is the need to sample from two separate
-distributions for one gradient computation.
-
 The applicability of quantum annealing-based neural networks has been
 demonstrated in MNIST [Den2012]_ image classification tasks [Zha2025]_,
 [Lay2024]_. Notably, [Lay2024]_ exploited the hardware topology of quantum
-annealers [Boo2019]_, [Boo2021]_ to implement a convolutional neural network
+annealers [Boo2019]_, [Boo2021]_ to implement a
+`convolutional neural network <https://en.wikipedia.org/wiki/Convolutional_neural_network>`_
 [Fuk1979]_, [Sch2015]_.
 
 A closely related approach is quantum reservoir computing [Kor2024]_.
@@ -1000,10 +1007,12 @@ modeling tasks.
 
 In a generative-model setup where annealing quantum computers are used as
 Boltzmann machine samplers, the natural comparison is to Monte Carlo samplers,
-such as the Metropolis algorithm [Met1953]_ [Rob2004]_. Metropolis algorithm
-sampling times can range from hundreds of milliseconds to seconds when sampling
-from the same Boltzmann machine as the annealing quantum computer for an
-equivalent effective sample size [Vat2021]_.
+such as the
+`Metropolis <https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm>`_
+algorithm [Met1953]_ [Rob2004]_. Metropolis algorithm sampling times can range
+from hundreds of milliseconds to seconds when sampling from the same Boltzmann
+machine as the annealing quantum computer for an equivalent effective sample
+size [Vat2021]_.
 
 For complex models, more sophisticated and compute-intensive methods such as
 parallel tempering [Gey1991]_ and annealed importance sampling [Nea2001]_ are
@@ -1039,10 +1048,9 @@ section.
 
 The two families of graphs are visualized in the :ref:`qpu_topologies` section.
 A key observation relevant to the discussion of expressivity is the locality of
-interactions. In both family of graphs, edges are locally connected in a
-two-dimensional plane and long-range interactions do not exist. These locality
-constraints motivate techniques for maximizing expressivity, which are discussed
-next.
+interactions: edges are locally connected in a two-dimensional plane and
+long-range interactions do not exist. These locality constraints motivate
+techniques for maximizing expressivity, which are discussed next.
 
 Several approaches exist to increase model expressivity.
 

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -621,9 +621,9 @@ statistic [Wai2008]_ of the model; i.e.,
         \end{bmatrix}^\intercal.
     \end{equation}
 
-More generally, given a graph :math:`G=(V, E)`, define a graph-restricted
-Boltzmann machine specified by :math:`G` to have sufficient statistics defined
-by,
+More generally, given a graph :math:`G=(V, E)`, you can define a
+graph-restricted Boltzmann machine specified by :math:`G` to have sufficient
+statistics defined by,
 
 .. math::
 
@@ -685,10 +685,9 @@ need for an efficient training algorithm [Hin2002]_, [Hin2010]_.
 Quantum Boltzmann machines offer a generalization of Boltzmann machines and are
 defined by Hamiltonians.
 
-In practice today (2026, the time of writing), at D-Wave the annealing quantum
-computer is utilized as an approximate sampler of quantum Boltzmann machines.
-Thus the following introductory definition only serves to satisfy one's
-curiosity: Refer to [Ami2018]_ for a complete treatment.
+In practice at D-Wave in 2026, the annealing quantum computer is used as an
+approximate sampler of quantum Boltzmann machines, as described briefly here and
+in detail in [Ami2018]_.
 
 In D-Wave's implementation, these Hamiltonians take the form:\ [#]_
 
@@ -732,14 +731,13 @@ probability (when normalized).
 When qubits are measured in the :math:`z`-basis, or with respect to each
 :math:`Z_i`, binary strings are observed with their corresponding probabilities.
 The quantum Boltzmann machine can be trained using the same expressions or
-quantities as in classical Boltzmann machines, albeit based on a lower bound of
-the log likelihood [Ami2018]_.
+quantities used in classical Boltzmann machines, albeit based on a lower bound
+of the log likelihood [Ami2018]_.
 
 .. [#]
 
-    The Hamiltonian is time-dependent but, motivated by ease of exposition, the
-    dependence on time has been omitted here. For a more complete treatment,
-    see the :ref:`qpu_quantum_annealing_intro` section.
+    The time-dependence of the Hamiltonian is omitted here for simplicity; for a
+    more complete treatment, see the :ref:`qpu_quantum_annealing_intro` section.
 
 Quantum Boltzmann Machines: Applications
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -984,27 +982,24 @@ computer has potential to improve upon classical baselines.
 2)  Model complexity
 3)  Power consumption
 
-First, a description of timing information of D-Wave's annealing quantum
-computers at a coarsened but practically relevant granularity.
-Quantum annealing protocols can operate in time spans as short as nanoseconds to
+A comprehensive description of timing information for D-Wave's annealing quantum
+computers is in the :ref:`qpu_operation_timing` section. Roughly, quantum
+annealing protocols can operate in time spans as short as nanoseconds to
 as long as milliseconds. Once the protocol has run its course, reading out the
 classical states takes on the order of hundreds of microseconds. The bottleneck
 in this protocol is in programming the Hamiltonian to the annealing quantum
-computer, which is on the order of tens of milliseconds.
-
-Because D-Wave's annealing quantum computers are accessed via |cloud_tm|_, a
-quantum cloud platform, there may be additional network latencies in the order
-of hundreds of milliseconds. In principle, communication latency can be
-mitigated and programming time optimized such that the effective processing time
-is on the order of tens of milliseconds.
-A comprehensive breakdown of timing information is in the
-:ref:`qpu_operation_timing` section.
+computer, which is on the order of tens of milliseconds. Because D-Wave's
+annealing quantum computers are accessed via |cloud_tm|_, a quantum cloud
+platform, there may be additional network latencies in the order of hundreds of
+milliseconds. In principle, communication latency can be mitigated and
+programming time optimized such that the effective processing time is on the
+order of tens of milliseconds.
 
 To put this timing in context, consider both generative and discriminative
 modeling tasks.
 
-In a generative model setup where annealing quantum computers are utilized as
-Boltzmann machine samplers, the natural comparators are Monte Carlo samplers
+In a generative-model setup where annealing quantum computers are used as
+Boltzmann machine samplers, the natural comparison is to Monte Carlo samplers,
 such as the Metropolis algorithm [Met1953]_ [Rob2004]_. Metropolis algorithm
 sampling times can range from hundreds of milliseconds to seconds when sampling
 from the same Boltzmann machine as the annealing quantum computer for an

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -1048,9 +1048,9 @@ section.
 
 The two families of graphs are visualized in the :ref:`qpu_topologies` section.
 A key observation relevant to the discussion of expressivity is the locality of
-interactions: edges are locally connected in a two-dimensional plane and
-long-range interactions do not exist. These locality constraints motivate
-techniques for maximizing expressivity, which are discussed next.
+interactions: are connected in a quasi-2D lattice and long-range interactiond do
+not exist. These locality constraints motivate techniques for maximizing
+expressivity, which are discussed next.
 
 Several approaches exist to increase model expressivity.
 

--- a/docs/quantum_research/stating_problems.rst
+++ b/docs/quantum_research/stating_problems.rst
@@ -777,14 +777,15 @@ descent: gradients are zero for discrete random variables. [Rol2016]_ addresses
 this training problem by augmenting binary latent variables with real-valued
 random variables. The auxiliary variables are equipped with distributions
 conditioned on the binary variables, resulting in nonzero gradients in
-backpropagation [Sch2015]_.
+`backpropagation <https://en.wikipedia.org/wiki/Backpropagation>`_ [Sch2015]_.
 
 For example, consider the random variable :math:`Z \mid B` where :math:`B` is a
 Bernoulli random variable and :math:`Z \mid B = 0` is :math:`0`, and
 :math:`Z \mid B = 1 \sim \text{Exponential}(1)`.
 
-Using the inverse conditional distribution function (CDF) sampling method
-[Rob2004]_, you have,
+Using the
+`inverse conditional distribution function <https://en.wikipedia.org/wiki/Inverse_transform_sampling>`_
+(CDF) sampling method [Rob2004]_, you have,
 
 .. math::
 
@@ -798,11 +799,9 @@ Using the inverse conditional distribution function (CDF) sampling method
     \end{align}
 
 where :math:`u` is the *noise variable*, :math:`x` is the encoded data input,
-and the second case for :math:`f` comes from the
-`inverse CDF <https://en.wikipedia.org/wiki/Inverse_transform_sampling>`_
-of the exponential distribution. Because :math:`f` is differentiable with
-nonzero gradients, one can meaningfully backpropagate through the discretization
-layer.
+and the second case for :math:`f` comes from the inverse CDF of the exponential
+distribution. Because :math:`f` is differentiable with nonzero gradients, one
+can meaningfully backpropagate through the discretization layer.
 
 Another approach to modeling data with binary random variables is to use
 approximations proposed by [Jan2016]_, [Mad2016]_. The approach is based on a


### PR DESCRIPTION
I did only the minimum to integrate this into the full _Machine Learning_ section in order to get it out quickly. We can combine with the RBM content of the _Sampling from the D-Wave QPU_ section with lower priority later.