### PR TITLE
docs: add Advantage2 mention alongside Advantage in overview

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -125,7 +125,7 @@ Welcome to |dwave_short|
         :ref:`qpu_quantum_annealing_intro` section.
 
         Quantum annealing is implemented in |dwave_short|'s generally available
-        quantum computers, such as the |dwave_5kq_tm| system, as a single
+        quantum computers, such as the |dwave_5kq_tm| and |adv2_tm| systems, as a single
         quantum algorithm, and this scalable approach to quantum computing has
         enabled us to create quantum processing units (:term:`QPUs <QPU>`) with
         more than 5000 quantum bits (:term:`qubits <qubit>`)---far beyond the


### PR DESCRIPTION
Fixes #367.

The "What D-Wave Does" section in `docs/index.rst` referenced only the Advantage™ system as an example of a generally available D-Wave quantum computer. Updated to also include the Advantage2™ system.

**Change:**
```
- quantum computers, such as the |dwave_5kq_tm| system, as a single
+ quantum computers, such as the |dwave_5kq_tm| and |adv2_tm| systems, as a single
```

## AI Generation Disclosure
No AI tools used.
