### PR TITLE
Fix typos in docs and description for canceling multiple problems in SAPI REST docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -409,7 +409,7 @@ rst_epilog = """
 .. |nlstride_short| unicode:: Stride U+00A0 solver
 .. |nlstride_tm| unicode:: Stride U+2122 U+00A0 hybrid U+00A0 solver
 
-.. |support_email| replace:: D U+2011 Wave Customer Support
+.. |support_email| unicode:: D U+2011 Wave U+00A0 Customer U+00A0 Support
 .. _support_email: support@dwavesys.com
 
 .. |doc_operations| replace:: *D-Wave Quantum Computer Operations*

--- a/docs/industrial_optimization/scaling.rst
+++ b/docs/industrial_optimization/scaling.rst
@@ -9,7 +9,7 @@ problems of the industrial scale supported by quantum-classical hybrid solvers
 in the `Leap <https://cloud.dwavesys.com/leap>`_ service.
 
 The code examples below focus on
-:ref:`constrained quadratic models (CQMs) <concept_models_cqm>`, non
+:ref:`constrained quadratic models (CQMs) <concept_models_cqm>`, not
 :ref:`nonlinear models <concept_models_nonlinear>`. (Most the guidance is also
 applicable to :ref:`binary quadratic models (BQMs) <concept_models_bqm>` and
 :ref:`quadratic models (QMs) <concept_models_quadratic>` in general.)

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -992,8 +992,7 @@ DELETE request to the ``problems`` endpoint.
 The ``Accept`` header should be set to
 ``application/vnd.dwave.sapi.problems+json; version=3``.
 
-The request body should be a JSON-encoded list of problem IDs; if the request
-body is omitted or contains an empty list, an error is returned.
+The request body should be a JSON-encoded list of problem IDs.
 
 When possible, if you have more than one problem to cancel, submit them in a
 single query.

--- a/docs/leap_sapi/sapi_rest.rst
+++ b/docs/leap_sapi/sapi_rest.rst
@@ -993,7 +993,7 @@ The ``Accept`` header should be set to
 ``application/vnd.dwave.sapi.problems+json; version=3``.
 
 The request body should be a JSON-encoded list of problem IDs; if the request
-body is empty, the request has no effect.
+body is omitted or contains an empty list, an error is returned.
 
 When possible, if you have more than one problem to cancel, submit them in a
 single query.
@@ -1063,6 +1063,7 @@ single query.
 
     |general error responses|
 
+    *   ``400`` for no list or an empty list of problem IDs
     *   ``404`` for nonexistent problem ID
     *   ``409`` for a problem that reached a terminal states before the request
 


### PR DESCRIPTION
- For the correction to the description and the error responses for canceling multiple problems, see the [Cancelling Multiple Problems](https://output.circle-artifacts.com/output/job/3d127909-0818-438f-8381-38ecc3900ba3/artifacts/0/docs/_build/html/leap_sapi/sapi_rest.html#cancel-multiple-problems) topic.
- To verify the typo fix, make sure the text "D-Wave Customer Support" displays correctly in the [Managing Projects](https://output.circle-artifacts.com/output/job/3d127909-0818-438f-8381-38ecc3900ba3/artifacts/0/docs/_build/html/leap_sapi/admin.html#admin-managing-projects) topic.
- To verify the typo fix, see the [Scaling for Production](https://output.circle-artifacts.com/output/job/3d127909-0818-438f-8381-38ecc3900ba3/artifacts/0/docs/_build/html/industrial_optimization/scaling.html#opt-scaling) topic.

#### AI Generation Disclosure

No AI tools used.