### PR TITLE
Update sitemap & canonical tags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,7 @@ extensions = [
     'reno.sphinxext',
     'sphinx_copybutton',
     'hoverxref.extension',
+    'sphinx_sitemap',
 ]
 
 autosummary_generate = True
@@ -64,6 +65,10 @@ numfig = True
 hoverxref_roles = ['term']
 hoverxref_role_types = {'term': 'tooltip'}
 hoverxref_mathjax = True
+
+# SEO and canonical tags:
+html_baseurl = 'https://docs.dwavequantum.com/en/latest/'
+sitemap_url_scheme = "{link}"
 
 source_suffix = {'.rst': 'restructuredtext', '.md': 'restructuredtext'}
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@ sphinx==8.2.3
 sphinx-design==0.6.1
 sphinx-copybutton==0.5.2
 sphinx-hoverxref==1.4.2
+sphinx-sitemap==2.9.0
 reno[sphinx]==3.3.0
 
 # skip numpy 2.4.0 due to a bug fixed in numpy#30500 (see dwave-samplers#82)


### PR DESCRIPTION
#### What does this implement/fix?
Sitemap will list all pages instead of just top page and adds canonical tags.

#### AI Generation Disclosure
No AI tools used though the request to make this update might have been based on AI recommendations. 
