### PR TITLE
Add the package version numbers to the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -301,6 +301,9 @@ def substitute_versions(app, docname, source):
     from dwave.system import __version__ as system_version
     source[0] = source[0].replace("|system_version|", system_version)
 
+    from dwaveoceansdk import __version__ as sdk_version
+    source[0] = source[0].replace("|sdk_version|", sdk_version)
+
     from minorminer import __version__ as minorminer_version
     source[0] = source[0].replace("|minorminer_version|", minorminer_version)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,6 @@ copyright = 'D-Wave'
 
 rst_prolog = f"""
 .. |python_requires| replace:: {python_requires}
-.. |sdk_version| replace:: {version}
 """
 
 # -- General configuration ------------------------------------------------
@@ -300,9 +299,6 @@ def substitute_versions(app, docname, source):
 
     from dwave.system import __version__ as system_version
     source[0] = source[0].replace("|system_version|", system_version)
-
-    from dwaveoceansdk import __version__ as sdk_version
-    source[0] = source[0].replace("|sdk_version|", sdk_version)
 
     from minorminer import __version__ as minorminer_version
     source[0] = source[0].replace("|minorminer_version|", minorminer_version)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -262,7 +262,51 @@ html_sidebars = {
 }
 html_static_path = ['_static']
 
+def substitute_versions(app, docname, source):
+    # Unfortunately we cannot use rst_prolog or rst_epilog within a
+    # toctree, so we need a more blunt instrument
+
+    # We only want to do the substitutions in packages.rst, so otherwise skip.
+    # The substitution should be harmless but this speeds things up a tiny bit
+    if "packages" not in docname:
+        return
+
+    from dimod import __version__ as dimod_version
+    source[0] = source[0].replace("|dimod_version|", dimod_version)
+
+    from dwave.cloud.client import __version__ as cloud_version
+    source[0] = source[0].replace("|cloud_version|", cloud_version)
+
+    from dwave.gate import __version__ as gate_version
+    source[0] = source[0].replace("|gate_version|", gate_version)
+
+    from hybrid import __version__ as hybrid_version
+    source[0] = source[0].replace("|hybrid_version|", hybrid_version)
+
+    from dwave.inspector import __version__ as inspector_version
+    source[0] = source[0].replace("|inspector_version|", inspector_version)
+
+    from dwave_networkx import __version__ as dnx_version
+    source[0] = source[0].replace("|dnx_version|", dnx_version)
+
+    from dwave.optimization import __version__ as optimization_version
+    source[0] = source[0].replace("|optimization_version|", optimization_version)
+
+    from dwave.preprocessing import __version__ as preprocessing_version
+    source[0] = source[0].replace("|preprocessing_version|", preprocessing_version)
+
+    from dwave.samplers import __version__ as samplers_version
+    source[0] = source[0].replace("|samplers_version|", samplers_version)
+
+    from dwave.system import __version__ as system_version
+    source[0] = source[0].replace("|system_version|", system_version)
+
+    from minorminer import __version__ as minorminer_version
+    source[0] = source[0].replace("|minorminer_version|", minorminer_version)
+
+
 def setup(app):
+   app.connect("source-read", substitute_versions)
    app.add_css_file('theme_overrides.css')
    app.add_css_file('cookie_notice.css')
    app.add_js_file('cookie_notice.js')

--- a/docs/ocean/packages.rst
+++ b/docs/ocean/packages.rst
@@ -8,23 +8,23 @@ Reference Documentation
     :hidden:
     :maxdepth: 1
 
-    dimod |dimod_version| <api_ref_dimod/index>
-    dwavebinarycsp (deprecated) <api_ref_binarycsp>
-    dwave-cloud-client |cloud_version| <api_ref_cloud/index>
-    dwave-gate |gate_version| <api_ref_gate/index>
-    dwave-hybrid |hybrid_version| <api_ref_hybrid/index>
-    dwave-inspector |inspector_version| <api_ref_inspector/index>
-    dwave-networkx |dnx_version| <api_ref_dnx/index>
-    dwave-optimization |optimization_version| <api_ref_optimization/index>
-    dwave-preprocessing |preprocessing_version| <api_ref_preprocessing/index>
-    dwave-samplers |samplers_version| <api_ref_samplers/index>
-    dwave-system |system_version| <api_ref_system/index>
-    minorminer |minorminer_version| <api_ref_minorminer/source/index>
-    penaltymodel (deprecated) <api_ref_penaltymodel/index>
+    dimod — |dimod_version| <api_ref_dimod/index>
+    dwavebinarycsp — deprecated <api_ref_binarycsp>
+    dwave-cloud-client — |cloud_version| <api_ref_cloud/index>
+    dwave-gate — |gate_version| <api_ref_gate/index>
+    dwave-hybrid — |hybrid_version| <api_ref_hybrid/index>
+    dwave-inspector — |inspector_version| <api_ref_inspector/index>
+    dwave-networkx — |dnx_version| <api_ref_dnx/index>
+    dwave-optimization — |optimization_version| <api_ref_optimization/index>
+    dwave-preprocessing — |preprocessing_version| <api_ref_preprocessing/index>
+    dwave-samplers — |samplers_version| <api_ref_samplers/index>
+    dwave-system — |system_version| <api_ref_system/index>
+    minorminer — |minorminer_version| <api_ref_minorminer/source/index>
+    penaltymodel — deprecated <api_ref_penaltymodel/index>
 
 .. packages-start-marker
 
-.. dropdown::  :ref:`dimod <index_dimod>` |dimod_version|: Quadratic models (BQM, CQM).
+.. dropdown::  :ref:`dimod <index_dimod>` (|dimod_version|): Quadratic models (BQM, CQM).
 
     Shared API for binary quadratic :term:`samplers <sampler>`. Provides a
     binary quadratic model (:term:`BQM`) class, which contains :term:`Ising` and
@@ -36,7 +36,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dimod>`
 
-.. dropdown:: :ref:`dwave-cloud-client <index_cloud>` |cloud_version|: API
+.. dropdown:: :ref:`dwave-cloud-client <index_cloud>` (|cloud_version|): API
     client to the Leap service's solvers.
 
     Minimal implementation of the REST interface used to communicate with
@@ -44,14 +44,14 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-cloud-client>`
 
-.. dropdown:: :ref:`dwave-gate <index_gate>` |gate_version|: Package for quantum
+.. dropdown:: :ref:`dwave-gate <index_gate>` (|gate_version|): Package for quantum
     circuits.
 
     A software package for constructing, modifying and running quantum circuits.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-gate>`
 
-.. dropdown:: :ref:`dwave-hybrid <index_hybrid>` |hybrid_version|: Framework for
+.. dropdown:: :ref:`dwave-hybrid <index_hybrid>` (|hybrid_version|): Framework for
     building hybrid solvers.
 
     A general, minimal Python framework for building :term:`hybrid` asynchronous
@@ -60,7 +60,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-hybrid>`
 
-.. dropdown:: :ref:`dwave-inspector <index_inspector>` |inspector_version|:
+.. dropdown:: :ref:`dwave-inspector <index_inspector>` (|inspector_version|):
     Visualizer for problems submitted to quantum computers.
 
     A tool for visualizing problems submitted to, and answers received from, a
@@ -69,7 +69,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-inspector>`
 
-.. dropdown:: :ref:`dwave-networkx <index_dnx>` |dnx_version|: NetworkX extension.
+.. dropdown:: :ref:`dwave-networkx <index_dnx>` (|dnx_version|): NetworkX extension.
 
     Extension of :std:doc:`NetworkX <networkx:index>`---a Python language
     package for exploration and analysis of networks and network
@@ -82,14 +82,14 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-networkx>`
 
-.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>` |version|: Ocean
+.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>` (|version|): Ocean
     software development kit.
 
     Installer for D-Wave's Ocean Tools.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-ocean-sdk>`
 
-.. dropdown:: :ref:`dwave-optimization <index_optimization>` |optimization_version|:
+.. dropdown:: :ref:`dwave-optimization <index_optimization>` (|optimization_version|):
     Nonlinear models.
 
     API for :ref:`nonlinear models <concept_models_nonlinear>`. The package
@@ -101,14 +101,14 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-optimization>`
 
-.. dropdown:: :ref:`dwave-preprocessing <index_preprocessing>` |preprocessing_version|:
+.. dropdown:: :ref:`dwave-preprocessing <index_preprocessing>` (|preprocessing_version|):
     Preprocessing tools for quadratic models.
 
     Library containing common preprocessing tools for quadratic models.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-preprocessing>`
 
-.. dropdown:: :ref:`dwave-samplers <index_samplers>` |samplers_version|: Classical algorithms
+.. dropdown:: :ref:`dwave-samplers <index_samplers>` (|samplers_version|): Classical algorithms
     for solving binary quadratic models.
 
     A library that implements the following classical algorithms as
@@ -128,7 +128,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-samplers>`
 
-.. dropdown:: :ref:`dwave-system <index_system>` |system_version|: D-Wave
+.. dropdown:: :ref:`dwave-system <index_system>` (|system_version|): D-Wave
     samplers and composites.
 
     Basic API for easily incorporating the |dwave_short| quantum computer as a
@@ -143,7 +143,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-system>`
 
-.. dropdown:: :ref:`minorminer <index_minorminer>` |minorminer_version|:
+.. dropdown:: :ref:`minorminer <index_minorminer>` (|minorminer_version|):
     Minor-embeds graphs.
 
     A tool for finding graph :term:`minor-embedding`, developed to embed

--- a/docs/ocean/packages.rst
+++ b/docs/ocean/packages.rst
@@ -24,7 +24,7 @@ Reference Documentation
 
 .. packages-start-marker
 
-.. dropdown::  :ref:`dimod <index_dimod>`: Quadratic models (BQM, CQM).
+.. dropdown::  :ref:`dimod <index_dimod>` |dimod_version|: Quadratic models (BQM, CQM).
 
     Shared API for binary quadratic :term:`samplers <sampler>`. Provides a
     binary quadratic model (:term:`BQM`) class, which contains :term:`Ising` and
@@ -36,22 +36,23 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dimod>`
 
-.. dropdown:: :ref:`dwave-cloud-client <index_cloud>`: API client to the
-    Leap service's solvers.
+.. dropdown:: :ref:`dwave-cloud-client <index_cloud>` |cloud_version|: API
+    client to the Leap service's solvers.
 
     Minimal implementation of the REST interface used to communicate with
     :term:`SAPI` servers.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-cloud-client>`
 
-.. dropdown:: :ref:`dwave-gate <index_gate>`: Package for quantum circuits.
+.. dropdown:: :ref:`dwave-gate <index_gate>` |gate_version|: Package for quantum
+    circuits.
 
     A software package for constructing, modifying and running quantum circuits.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-gate>`
 
-.. dropdown:: :ref:`dwave-hybrid <index_hybrid>`: Framework for building hybrid
-    solvers.
+.. dropdown:: :ref:`dwave-hybrid <index_hybrid>` |hybrid_version|: Framework for
+    building hybrid solvers.
 
     A general, minimal Python framework for building :term:`hybrid` asynchronous
     decomposition samplers for quadratic unconstrained binary optimization
@@ -59,8 +60,8 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-hybrid>`
 
-.. dropdown:: :ref:`dwave-inspector <index_inspector>`: Visualizer for problems
-    submitted to quantum computers.
+.. dropdown:: :ref:`dwave-inspector <index_inspector>` |inspector_version|:
+    Visualizer for problems submitted to quantum computers.
 
     A tool for visualizing problems submitted to, and answers received from, a
     |dwave_short| structured solver such as an :term:`Advantage` quantum
@@ -68,7 +69,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-inspector>`
 
-.. dropdown:: :ref:`dwave-networkx <index_dnx>`: NetworkX extension.
+.. dropdown:: :ref:`dwave-networkx <index_dnx>` |dnx_version|: NetworkX extension.
 
     Extension of :std:doc:`NetworkX <networkx:index>`---a Python language
     package for exploration and analysis of networks and network
@@ -81,14 +82,15 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-networkx>`
 
-.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>`: Ocean software
-    development kit.
+.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>` |sdk_version|: Ocean
+    software development kit.
 
     Installer for D-Wave's Ocean Tools.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-ocean-sdk>`
 
-.. dropdown:: :ref:`dwave-optimization <index_optimization>`: Nonlinear models.
+.. dropdown:: :ref:`dwave-optimization <index_optimization>` |optimization_version|:
+    Nonlinear models.
 
     API for :ref:`nonlinear models <concept_models_nonlinear>`. The package
     includes:
@@ -99,15 +101,15 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-optimization>`
 
-.. dropdown:: :ref:`dwave-preprocessing <index_preprocessing>`: Preprocessing
-    tools for quadratic models.
+.. dropdown:: :ref:`dwave-preprocessing <index_preprocessing>` |preprocessing_version|:
+    Preprocessing tools for quadratic models.
 
     Library containing common preprocessing tools for quadratic models.
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-preprocessing>`
 
-.. dropdown:: :ref:`dwave-samplers <index_samplers>`: Classical algorithms for solving binary
-    quadratic models.
+.. dropdown:: :ref:`dwave-samplers <index_samplers>` |samplers_version|: Classical algorithms
+    for solving binary quadratic models.
 
     A library that implements the following classical algorithms as
     :term:`samplers <sampler>` for solving binary quadratic models
@@ -126,8 +128,8 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-samplers>`
 
-.. dropdown:: :ref:`dwave-system <index_system>`: D-Wave samplers and
-    composites.
+.. dropdown:: :ref:`dwave-system <index_system>` |system_version|: D-Wave
+    samplers and composites.
 
     Basic API for easily incorporating the |dwave_short| quantum computer as a
     :term:`sampler` in the Ocean :ref:`software stack <ocean_stack>`.
@@ -141,7 +143,8 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-system>`
 
-.. dropdown:: :ref:`minorminer <index_minorminer>`: Minor-embeds graphs.
+.. dropdown:: :ref:`minorminer <index_minorminer>` |minorminer_version|:
+    Minor-embeds graphs.
 
     A tool for finding graph :term:`minor-embedding`, developed to embed
     :term:`Ising` problems onto :term:`quantum annealing` (QA) quantum
@@ -153,8 +156,8 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/minorminer>`
 
-.. dropdown:: :ref:`penaltymodel <index_penaltymodel>`: Maps constraints to binary
-    quadratic models.
+.. dropdown:: :ref:`penaltymodel <index_penaltymodel>` (deprecated): Maps
+    constraints to binary quadratic models.
 
     An approach to solve a constraint satisfaction problem (:term:`CSP`) using
     an :term:`Ising` model or a :term:`QUBO`, is to map each individual

--- a/docs/ocean/packages.rst
+++ b/docs/ocean/packages.rst
@@ -8,19 +8,19 @@ Reference Documentation
     :hidden:
     :maxdepth: 1
 
-    api_ref_dimod/index
-    api_ref_binarycsp
-    api_ref_cloud/index
-    api_ref_gate/index
-    api_ref_hybrid/index
-    api_ref_inspector/index
-    api_ref_dnx/index
-    api_ref_optimization/index
-    api_ref_preprocessing/index
-    api_ref_samplers/index
-    api_ref_system/index
-    api_ref_minorminer/source/index
-    api_ref_penaltymodel/index
+    dimod |dimod_version| <api_ref_dimod/index>
+    dwavebinarycsp (deprecated) <api_ref_binarycsp>
+    dwave-cloud-client |cloud_version| <api_ref_cloud/index>
+    dwave-gate |gate_version| <api_ref_gate/index>
+    dwave-hybrid |hybrid_version| <api_ref_hybrid/index>
+    dwave-inspector |inspector_version| <api_ref_inspector/index>
+    dwave-networkx |dnx_version| <api_ref_dnx/index>
+    dwave-optimization |optimization_version| <api_ref_optimization/index>
+    dwave-preprocessing |preprocessing_version| <api_ref_preprocessing/index>
+    dwave-samplers |samplers_version| <api_ref_samplers/index>
+    dwave-system |system_version| <api_ref_system/index>
+    minorminer |minorminer_version| <api_ref_minorminer/source/index>
+    penaltymodel (deprecated) <api_ref_penaltymodel/index>
 
 .. packages-start-marker
 

--- a/docs/ocean/packages.rst
+++ b/docs/ocean/packages.rst
@@ -82,7 +82,7 @@ Reference Documentation
 
     :bdg-link-primary:`code <https://github.com/dwavesystems/dwave-networkx>`
 
-.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>` |sdk_version|: Ocean
+.. dropdown:: :ref:`dwave-ocean-sdk <ocean_source_code>` |version|: Ocean
     software development kit.
 
     Installer for D-Wave's Ocean Tools.


### PR DESCRIPTION
Feels useful to see the version of the package that's in the docs.

### Before
<img width="371" height="565" alt="image" src="https://github.com/user-attachments/assets/96db862a-61d1-4b96-95e6-d456ecd304d3" />

### After
<img width="371" height="565" alt="image" src="https://github.com/user-attachments/assets/1f686429-a8ee-421c-8455-62010078c484" />

#### AI Generation Disclosure
No AI used.
