### PR TITLE
Build docs in parallel by default

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -jauto
 SPHINXBUILD   = python -msphinx
 SPHINXPROJ    = D-WaveSystemsDocumentation
 SOURCEDIR     = .


### PR DESCRIPTION
This defaults to using the number of CPU cores. I think this is quite safe and speeds up builds locally and in CI.

#### AI Generation Disclosure
No AI used.
