### PR TITLE
Release 9.4.0

### DIFF
--- a/dwaveoceansdk/__init__.py
+++ b/dwaveoceansdk/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '9.3.0'
+__version__ = '9.4.0'


### PR DESCRIPTION
# Changelog

## `dimod` 0.12.21 ➞ 0.12.22

### Prelude

Binary and constrained quadratic model generators that used to reside in
`dwave-networkx` (now `dwave-graphs`) have been moved to
`dimod.generators`.

### New Features

- Add generators for binary quadratic models with ground states
  corresponding to a vertex coloring
  (`dimod.generators.vertex_coloring`) and a minimum vertex coloring
  (`dimod.generators.min_vertex_coloring`).

<!-- -->

- Add a binary quadratic model generator for a Markov network
  (`dimod.generators.markov_network`).

<!-- -->

- Add generators binary quadratic models with ground states
  corresponding to a graph matching (`dimod.generators.matching`),
  graph's maximal matching (`dimod.generators.maximal_matching`) and
  graph's minimum maximal matching
  (`dimod.generators.min_maximal_matching`).

<!-- -->

- Add a generator for a constrained quadratic model with ground states
  corresponding to a balanced k-partition of graph
  (`dimod.generators.graph_partition`).

<!-- -->

- Add a binary quadratic model generator to calculate the structural
  imbalance of a signed social network
  (`dimod.generators.structural_imbalance`).

<!-- -->

- Add a generator for a binary quadratic model with ground states
  corresponding to a minimum TSP route
  (`dimod.generators.traveling_salesperson`).

<!-- -->

- Add support for NetworkX graph output during function argument
  coercion via `@graph_argument(..., as_networkx=True)`.

<!-- -->

- Add estimator for effective sample size based on
  [Revisiting the Gelman-Rubin Diagnostic https://arxiv.org/abs/1812.09384](Revisiting%20the%20Gelman-Rubin%20Diagnostic%20https://arxiv.org/abs/1812.09384).

### Upgrade Notes

- Drop support for Python 3.9.

### Bug Fixes

- To avoid `@graph_argument(..., as_networkx=True)` failing during
  import/compile time, defer `networkx` checks to the decorated function
  run time.


## `dwave-cloud-client` 0.14.4 ➞ 0.14.6

### New Features

- Introduce `Solver.minimal_problem`, a new solver property that returns
  a minimal problem accepted by the solver, together with a set of
  parameter values required to successfully submit the problem to SAPI.

<!-- -->

- Expand the solver interface to include `sample_problem()` and
  `upload_problem()` (previously available only on unstructured
  solvers).

<!-- -->

- Add `dwave region ls` CLI command to list available regions.

<!-- -->

- Add support for gate-model quantum circuit (QCDL) solvers in SAPI.

<!-- -->

- Add CLI flag `-c` as an alias for `--client`.

  Note that `-c` (previously short for `--config-file`) was deprecated
  in 0.8.5, and removed in 0.10.0, so that it could be repurposed as a
  short form of `--client`.

<!-- -->

- Make `CachingSessionMixin` safer by replacing DiskCache's default
  `pickle` serialization with JSON (for response headers) + raw binary
  (for response content).

<!-- -->

- Use JSON serialization for auth credentials (instead of DiskCache's
  default `pickle`).

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx` for QPU
  graph generation.


## `dwave-graphs` 1.0.0 (new)

### Prelude

Create `dwave-graphs` package based off `dwave-networkx`.
`dwave_networkx` namespace is renamed to `dwave.graphs`.

Binary quadratic model (i.e. Ising model and QUBO) generators have been
moved from `dwave.graphs.algorithms` to `dimod.generators`.

### New Features

- Add support for Python 3.14.

<!-- -->

- Modernize package config.

### Upgrade Notes

- Drop support for Python 3.9.

<!-- -->

- Drop support for `dimod<0.12`.

<!-- -->

- Remove deprecated Chimera and Pegasus coordinates transformation alias
  methods (`int`/`tuple`/etc in favor of explicit e.g.
  `chimera_to_linear`).

<!-- -->

- Remove deprecated `is_matching` and `is_maximal_matching` functions
  from `dwave.graphs.algorithms.matching`. Use the NetworkX
  implementations instead.

<!-- -->

- Drop the default sampler interface previously available in
  `dwave-networkx`. Some algorithms now explicitly require a sampler.

<!-- -->

- Drop `utils` and `utils.decorators` submodules, as well as the
  `@binary_quadratic_model_sampler` decorator.

<!-- -->

- All BQM/Ising/QUBO generators from `dwave.graphs.algorithms` have been
  migrated to `dimod.generators` (released in `dimod==0.12.22`):
  - `min_vertex_color_qubo` and `vertex_color_qubo` removed from
    `dwave.graphs.algorithms.coloring` in favor of `min_vertex_coloring`
    and `vertex_coloring` from `dimod.generators.coloring`,
  - `dwave.graphs.algorithms.markov.markov_network_bqm` removed in favor
    of `dimod.generators.markov.markov_network`,
  - `matching_bqm`, `maximal_matching_bqm` and
    `min_maximal_matching_bqm` removed from
    `dwave.graphs.algorithms.matching` in favor of `maximal_matching`
    and `min_maximal_matching` from `dimod.generators.matching`,
  - `dwave.graphs.algorithms.partition.graph_partition_cqm` removed in
    favor of `dimod.generators.partition.graph_partition`,
  - `dwave.graphs.algorithms.social.structural_imbalance_ising` removed
    in favor of `dimod.generators.social.structural_imbalance` and
  - `dwave.graphs.algorithms.tsp.traveling_salesperson_qubo` removed in
    favor of `dimod.generators.tsp.traveling_salesperson`.

<!-- -->

- Drop support for `dimod<0.12.22`.

<!-- -->

- Drop `vertex_color` and `min_vertex_color` aliases in favor of
  `vertex_coloring` and `min_vertex_coloring` for consistency.

<!-- -->

- Drop support for NumPy 1.x.

<!-- -->

- Replace dev/test/docs `requirements.txt` files with Dependency Groups
  (PEP-735).

<!-- -->

- `dwave.graphs.topologies` renamed to `dwave.graphs.topologies`.

<!-- -->

- Topology specific coloring functions, `zephyr_four_color()`,
  `pegasus_four_color()`, and `chimera_two_color()`, are moved from
  `dwave.graphs.topologies` to `dwave.graphs.algorithms.coloring`.


## `dwave-hybrid` 0.6.15 ➞ 1.6.16

### Upgrade Notes

- Drop NumPy 1.x support.

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`. See [\#312](https://github.com/dwavesystems/dwave-hybrid/pull/312).


## `dwave-networkx` 0.8.18 ➞ 0.8.19

### Prelude

`dwave-networkx` is deprecated and will be replaced by `dwave-graphs` in
Ocean 10. Most functionality previously provided by `dwave-networkx` is
now available as part of `dwave-graphs` under the `dwave.graphs`
namespace.

See [dwave-graphs](https://github.com/dwavesystems/dwave-graphs/releases/tag/1.0.0).

### New Features

- Add support for Python 3.14.

### Upgrade Notes

- Drop support for Python 3.9.

<!-- -->

- Drop support for `dimod<0.12`.

<!-- -->

- Algorithms previously provided in the `dwave_networkx.algorithms`
  module are now available in `dwave-graphs` under the
  `dwave.graphs.algorithms` namespace. Binary and constrained quadratic
  model generators have been moved to `dimod.generators`.

<!-- -->

- Graph drawing utilities previously provided in the
  `dwave_networkx.drawing` module are now available in `dwave-graphs`
  under the `dwave.graphs.drawing` namespace.

<!-- -->

- Graph generators previously provided in the
  `dwave_networkx.generators` module are now available in `dwave-graphs`
  under the `dwave.graphs.topologies` namespace.

<!-- -->

- Functionality previously provided in the
  `dwave_networkx.default_sampler` module has been removed in
  <span class="title-ref">dwave-graphs</span>.

<!-- -->

- Functionality previously provided in the `dwave_networkx.utils` module
  has been removed in `dwave-graphs`.


## `dwave-optimization` 0.6.11 ➞ 0.7.1

### New Features

- Sub-lists are now supported. 
  See https://github.com/dwavesystems/dwave-optimization/issues/71.

- Support ``numpy.newaxis`` and ``...`` while indexing array symbols.

- Add ``LinearProgram.feasible()`` and ``LinearProgram.objective_value()``
  methods. These allow the user to access information about the state of the
  linear program without needing the associated symbols.
  See https://github.com/dwavesystems/dwave-optimization/issues/475.

- The symbols: `All`, `Any`, `Max`, `Min`, `Prod`, and `Sum` can infer
  their size from their predecessor's size.

- `Transpose` symbol can infer its size from its predecessor's size.

-   Make C++ `BufferIterator` always shaped.
-   Implicit sum constraints added to NumberNode.
    -   Users may define a sum constraint over the entire array or along
        an single axis.
    -   Enabled at the Python level for BinaryVariable and
        IntegerVariable. See [#216](https://github.com/dwavesystems/dwave-optimization/issues/216).
    -   Added `NumberNode::sum_constraints()` (returns sum constraint).
    -   Added `NumberNode::sum_constraints_lhs()` (returns
        state-dependent sums associated with sum constraint).
    -   Modified `NumberNode::exchange()` to accept optional slice
        arguments.
    -   Modified `NumberNode::clip_and_set_value()` to accept optional
        slice argument.
    -   Modified `IntegerNode::set_value()` to accept optional slice
        argument.
    -   Modified `BinaryNode::flip()` to accept optional slice argument.
-   BinaryNode optionally tracks indices with buffer value 1 and 0.
    -   Enabled when users define a sum constraint.
    -   Added `BinaryNode::num_true()` (return \# of indices with buffer
        value 1 in slice given sum constraint).
    -   Added `BinaryNode::num_false()` (return \# of indices with
        buffer value 0 in slice given sum constraint).
    -   Added `BinaryNode::ith_true_index()` (returns ith index with
        buffer value 1 in slice given sum constraint).
    -   Added `BinaryNode::ith_false_index()` (returns ith index with
        buffer value 0 in slice given sum constraint).
-   Add three methods to the model returned by the job-shop scheduling
    model generator: `model.get_global_task_ordering()`,
    `model.get_start_times()`, and `model.get_end_times()`.

### Known Issues

- In some cases, combined indexing operations on high dimensional arrays will
  not match the behavior of NumPy.
  See https://github.com/dwavesystems/dwave-optimization/issues/465.

### Bug Fixes

- Fix an issue with advanced indexing when indexing a dynamic array with
  scalar indexers where the index on the first dimension is an empty slice,
  such as ``A[:, i, j, :]`` where ``i`` and ``j`` are scalar symbols. Previously,
  this may have resulted in a exception being raised when initializing a
  state on the model. This has now been fixed. A specific sub-case of this,
  when the scalar indexers are separated by an empty slice in at least one axis,
  (e.g. ``A[:, i, :, j]``) is not supported and is now properly disallowed with
  an exception being raised at symbol/node construction time.

-   Add missing includes to `dwave-optimization/functional.hpp`

-   Fix an issue with `ListVariable`s with a maximum size set to less  than `n`, the size of the main set. In this case the underlying node's state was not initialized correctly causing some valid operations to later fail.

-   Fix `MatrixMultiply` symbol when multiplying non-contiguous arrays and/or arrays with size 1 in one dimension. See [#553](https://github.com/dwavesystems/dwave-optimization/issues/553).

-   `IsInNode` previously did not clear cached state data during `commit()`, causing future propagation-and-reverts to encounter memory issues. The implementation has been fixed.

### Upgrade Notes

-   Drop support for contiguous C++ `BufferIterator`. This means that
    one must always provide a `shape` and `strides` argument when
    constructing the iterator.
-   Change `Array::view` to use `std::default_sentinel`. This means
    `Array::view` is no longer a `std::common_range`.
-   Drop the `Array::View` type declaration.
-   Update job-shop scheduling generator to use a list variable for the
    global ordering of all tasks from which the model constructs a
    feasible schedule.

### Deprecation Notes

-   Remove `NumberNode` and `BinaryNode` random state initialization.
-   Remove mutate methods `set()` and `unset()` from `BinaryNode`.


## `dwave-samplers` 1.7.0 ➞ 1.8.0

### New Features

- Build with <span class="title-ref">meson</span> rather than <span class="title-ref">setuptools</span>.

<!-- -->

- Use Python's limited API for Python 3.12+.


## `dwave-system` 1.34.0 ➞ 1.35.0

### New Features

- Update behavior of `ParallelEmbeddingComposite` so that under
  `auto_scale=True` all embedded bqms are rescaled independently to use
  the maximum available range.

<!-- -->

- The `LeapHybridNLSampler` class was made an alias for the
  `StrideHybridSolver` class.

### Upgrade Notes

- Drop NumPy 1.x support.

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`. See [\#609](https://github.com/dwavesystems/dwave-system/pull/609).


## `minorminer` 0.2.21 ➞ 0.2.22

### Upgrade Notes

- Drop NumPy 1.x support.

<!-- -->

- Rename `minorminer.layout.dnx_layout` to
  `minorminer.layout.graph_layout` and deprecate it, but keep an alias
  for backwards compatibility.

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`.


# Package versions

```
dimod==0.12.22
dwave-cloud-client==0.14.6
dwave-gate==0.3.5
dwave-graphs==1.0.0
dwave-hybrid==0.6.16
dwave-inspector==0.5.5
dwave-networkx==0.8.19
dwave-optimization==0.7.1
dwave-preprocessing==0.6.11
dwave-samplers==1.8.0
dwave-system==1.35.0
minorminer==0.2.22
penaltymodel==1.3.0
```
