### PR TITLE
Add QCP definition in What is QA, plus update some examples of properties

### DIFF
--- a/docs/concepts/index.rst
+++ b/docs/concepts/index.rst
@@ -505,6 +505,16 @@ Concepts and Terminology
         that uses Python as the host language to write instructions for a
         gate-model :term:`QPU`.
 
+    QCP
+        Quantum critical point. The point in the anneal where :math:`A(s)`, the
+        transverse or tunneling energy, and :math:`B(s)`, the energy applied to
+        the problem Hamiltonian, are of equal amplitudes.
+
+        Learn more:
+
+        *   :numref:`Figure %s <annealing-functions>` in the
+            :ref:`qpu_qa_implementation` section
+
     QMI
         Quantum machine instruction.
 

--- a/docs/industrial_optimization/solver_bqm_properties.rst
+++ b/docs/industrial_optimization/solver_bqm_properties.rst
@@ -148,7 +148,7 @@ Example
 ...
 >>> sampler = LeapHybridBQMSampler()                # doctest: +SKIP
 >>> sampler.properties["quota_conversion_rate"]     # doctest: +SKIP
-20
+1
 
 
 .. _property_bqm_supported_problem_types:

--- a/docs/industrial_optimization/solver_cqm_properties.rst
+++ b/docs/industrial_optimization/solver_cqm_properties.rst
@@ -273,7 +273,7 @@ Example
 ...
 >>> sampler = LeapHybridCQMSampler()                # doctest: +SKIP
 >>> sampler.properties["quota_conversion_rate"]     # doctest: +SKIP
-20
+1
 
 
 .. _property_cqm_supported_problem_types:

--- a/docs/industrial_optimization/solver_dqm_properties.rst
+++ b/docs/industrial_optimization/solver_dqm_properties.rst
@@ -171,7 +171,7 @@ Example
 ...
 >>> sampler = LeapHybridDQMSampler()                # doctest: +SKIP
 >>> sampler.properties["quota_conversion_rate"]     # doctest: +SKIP
-20
+1
 
 
 .. _property_dqm_supported_problem_types:

--- a/docs/industrial_optimization/solver_nl_properties.rst
+++ b/docs/industrial_optimization/solver_nl_properties.rst
@@ -200,7 +200,7 @@ Example
 ...
 >>> sampler = LeapHybridNLSampler()     # doctest: +SKIP
 >>> sampler.properties["quota_conversion_rate"]  # doctest: +SKIP
-20
+1
 
 
 .. _property_nl_state_size_multiplier:

--- a/docs/quantum_research/quantum_annealing_intro.rst
+++ b/docs/quantum_research/quantum_annealing_intro.rst
@@ -190,8 +190,8 @@ you can discern that the state with the apple on the table has a higher energy
 than that when the apple is on the floor.
 
 For a quantum system, a Hamiltonian is a function that maps certain states,
-called *eigenstates*, to energies. Only when the system is in an eigenstate of
-the Hamiltonian is its energy well defined and called the *eigenenergy*. When
+called *eigenstates*, to energies. The energy is well defined and called the
+*eigenenergy* only when the system is in an eigenstate of the Hamiltonian. When
 the system is in any other state, its energy is uncertain. The collection of
 eigenstates with defined eigenenergies make up the *eigenspectrum*.
 
@@ -311,8 +311,9 @@ the system.
 
     Annealing functions :math:`A(s)`, :math:`B(s)`. Annealing begins at
     :math:`s=0` with :math:`A(s) \gg B(s)` and ends at :math:`s=1` with
-    :math:`A(s) \ll B(s)`. Data shown are representative of |dwave_short|
-    2X systems.
+    :math:`A(s) \ll B(s)`. :term:`QCP` is the point where :math:`A(s)` and
+    :math:`B(s)` are of equal amplitude. Data shown are representative of
+    |dwave_short| 2X systems.
 
 
 Annealing Controls


### PR DESCRIPTION
#### Reference issue
DOC-813 & DOC-1094

#### What does this implement/fix?
Defines QCP in the What is Quantum Annealing section and updates examples of the ``quota_conversion_rate`` property.

#### AI Generation Disclosure
No AI tools used
